### PR TITLE
Usage support built in to the plan init

### DIFF
--- a/src/ShopifyApp/Libraries/BillingPlan.php
+++ b/src/ShopifyApp/Libraries/BillingPlan.php
@@ -151,7 +151,7 @@ class BillingPlan
             'trial_days'    => isset($this->details['trial_days']) ? $this->details['trial_days'] : 0,
             'name'          => $this->details['name'],
             'price'         => $this->details['price'],
-            'return_url'    => $this->details['return_url']
+            'return_url'    => $this->details['return_url'],
         ];
 
         // Handle capped amounts for UsageCharge API

--- a/src/ShopifyApp/Libraries/BillingPlan.php
+++ b/src/ShopifyApp/Libraries/BillingPlan.php
@@ -56,11 +56,13 @@ class BillingPlan
      *
      * @param array $plan The plan details.
      *                    $plan = [
-     *                    'name'         => (string) Plan name.
-     *                    'price'        => (float) Plan price. Required.
-     *                    'test'         => (boolean) Test mode or not.
-     *                    'trial_days'   => (int) Plan trial period in days.
-     *                    'return_url'   => (string) URL to handle response for acceptance or decline or billing. Required.
+     *                    'name'          => (string) Plan name.
+     *                    'price'         => (float) Plan price. Required.
+     *                    'test'          => (boolean) Test mode or not.
+     *                    'trial_days'    => (int) Plan trial period in days.
+     *                    'return_url'    => (string) URL to handle response for acceptance or decline or billing. Required.
+     *                    'capped_amount' => (float) Capped price if using UsageCharge API.
+     *                    'terms'         => (string) Terms for the usage. Required if using capped_amount.
      *                    ]
      *
      * @return $this
@@ -143,19 +145,26 @@ class BillingPlan
             throw new Exception('Plan details are missing for confirmation URL request.');
         }
 
+        // Build the charge array
+        $chargeDetails = [
+            'test'          => isset($this->details['test']) ? $this->details['test'] : false,
+            'trial_days'    => isset($this->details['trial_days']) ? $this->details['trial_days'] : 0,
+            'name'          => $this->details['name'],
+            'price'         => $this->details['price'],
+            'return_url'    => $this->details['return_url']
+        ];
+
+        // Handle capped amounts for UsageCharge API
+        if (isset($this->details['capped_amount'])) {
+            $chargeDetails['capped_amount'] = $this->details['capped_amount'];
+            $chargeDetails['terms'] = $this->details['terms'];
+        }
+
         // Begin the charge request
         $charge = $this->shop->api()->request(
             'POST',
             "/admin/{$this->chargeType}s.json",
-            [
-                "{$this->chargeType}" => [
-                    'test'       => isset($this->details['test']) ? $this->details['test'] : false,
-                    'trial_days' => isset($this->details['trial_days']) ? $this->details['trial_days'] : 0,
-                    'name'       => $this->details['name'],
-                    'price'      => $this->details['price'],
-                    'return_url' => $this->details['return_url'],
-                ],
-            ]
+            ["{$this->chargeType}" => $chargeDetails]
         )->body->{$this->chargeType};
 
         return $charge->confirmation_url;

--- a/src/ShopifyApp/Traits/BillingControllerTrait.php
+++ b/src/ShopifyApp/Traits/BillingControllerTrait.php
@@ -65,13 +65,21 @@ trait BillingControllerTrait
      */
     protected function planDetails()
     {
-        return [
+        $plan = [
             'name'       => config('shopify-app.billing_plan'),
             'price'      => config('shopify-app.billing_price'),
             'test'       => config('shopify-app.billing_test'),
             'trial_days' => config('shopify-app.billing_trial_days'),
             'return_url' => url(config('shopify-app.billing_redirect')),
         ];
+
+        // Handle capped amounts for UsageCharge API
+        if (config('shopify-app.billing_capped_amount')) {
+            $plan['capped_amount'] = config('shopify-app.billing_capped_amount');
+            $plan['terms'] = config('shopify-app.billing_terms');
+        }
+
+        return $plan;
     }
 
     /**

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -186,6 +186,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Billing Capped Amount
+    |--------------------------------------------------------------------------
+    |
+    | The capped price for charging a customer when using the UsageCharge API.
+    |
+    */
+
+    'billing_capped_amount' => env('SHOPIFY_BILLING_CAPPED_AMOUNT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Billing Terms
+    |--------------------------------------------------------------------------
+    |
+    | Terms for the usage. Required if using capped amount.
+    |
+    */
+
+    'billing_terms' => env('SHOPIFY_BILLING_TERMS'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Shopify Webhooks
     |--------------------------------------------------------------------------
     |

--- a/tests/Controllers/BillingControllerTest.php
+++ b/tests/Controllers/BillingControllerTest.php
@@ -66,7 +66,7 @@ class BillingControllerTest extends TestCase
                 'price'      => config('shopify-app.billing_price'),
                 'test'       => config('shopify-app.billing_test'),
                 'trial_days' => config('shopify-app.billing_trial_days'),
-                'return_url' => url(config('shopify-app.billing_redirect'))
+                'return_url' => url(config('shopify-app.billing_redirect')),
             ],
             $method->invoke($controller, 'planDetails')
         );
@@ -90,7 +90,7 @@ class BillingControllerTest extends TestCase
                 'trial_days'    => config('shopify-app.billing_trial_days'),
                 'capped_amount' => config('shopify-app.billing_capped_amount'),
                 'terms'         => config('shopify-app.billing_terms'),
-                'return_url'    => url(config('shopify-app.billing_redirect'))
+                'return_url'    => url(config('shopify-app.billing_redirect')),
             ],
             $method->invoke($controller, 'planDetails')
         );

--- a/tests/Controllers/BillingControllerTest.php
+++ b/tests/Controllers/BillingControllerTest.php
@@ -66,8 +66,31 @@ class BillingControllerTest extends TestCase
                 'price'      => config('shopify-app.billing_price'),
                 'test'       => config('shopify-app.billing_test'),
                 'trial_days' => config('shopify-app.billing_trial_days'),
-                'return_url' => url(config('shopify-app.billing_redirect')),
+                'return_url' => url(config('shopify-app.billing_redirect'))
+            ],
+            $method->invoke($controller, 'planDetails')
+        );
+    }
 
+    public function testReturnsBasePlanDetailsWithUsage()
+    {
+        config(['shopify-app.billing_capped_amount' => 100.00]);
+        config(['shopify-app.billing_terms' => '$1 for 100 emails.']);
+
+        $controller = new BillingController();
+        $method = new ReflectionMethod(BillingController::class, 'planDetails');
+        $method->setAccessible(true);
+
+        // Based on default config
+        $this->assertEquals(
+            [
+                'name'          => config('shopify-app.billing_plan'),
+                'price'         => config('shopify-app.billing_price'),
+                'test'          => config('shopify-app.billing_test'),
+                'trial_days'    => config('shopify-app.billing_trial_days'),
+                'capped_amount' => config('shopify-app.billing_capped_amount'),
+                'terms'         => config('shopify-app.billing_terms'),
+                'return_url'    => url(config('shopify-app.billing_redirect'))
             ],
             $method->invoke($controller, 'planDetails')
         );

--- a/tests/Libraries/BillingPlanTest.php
+++ b/tests/Libraries/BillingPlanTest.php
@@ -36,6 +36,20 @@ class BillingPlanTest extends TestCase
         );
     }
 
+    public function testShouldReturnConfirmationUrlWhenUsageIsEnabled()
+    {
+        $plan = array_merge($this->plan, [
+            'capped_amount' => 100.00,
+            'terms' => '$1 for 500 emails',
+        ]);
+        $url = (new BillingPlan($this->shop))->setDetails($plan)->getConfirmationUrl();
+
+        $this->assertEquals(
+            'https://example.myshopify.com/admin/charges/1029266947/confirm_recurring_application_charge?signature=BAhpBANeWT0%3D--64de8739eb1e63a8f848382bb757b20343eb414f',
+            $url
+        );
+    }
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Plan details are missing for confirmation URL request.

--- a/tests/Libraries/BillingPlanTest.php
+++ b/tests/Libraries/BillingPlanTest.php
@@ -40,7 +40,7 @@ class BillingPlanTest extends TestCase
     {
         $plan = array_merge($this->plan, [
             'capped_amount' => 100.00,
-            'terms' => '$1 for 500 emails',
+            'terms'         => '$1 for 500 emails',
         ]);
         $url = (new BillingPlan($this->shop))->setDetails($plan)->getConfirmationUrl();
 


### PR DESCRIPTION
To support issue #21 this adds ability to pass `capped_amount` and `terms` to the billing screen.