### PR TITLE
[Feature] Update TravisCI for testing Laravel 5.6

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,0 @@
-coverage_clover: build/logs/clover.xml
-json_path: build/coveralls-upload.json
-service_name: travis-ci

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.php text
+*.default text
+*.ctp text
+*.sql text
+*.md text
+*.po text
+*.js text
+*.css linguist-vendored
+*.scss linguist-vendored
+*.ini text
+*.properties text
+*.txt text
+*.xml text
+*.yml text
+.htaccess text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+# font files
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Exclude unused files
+/tests              export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml        export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md    export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,24 @@
-build/
-vendor/
-tests/tmp/
-bin/
+# User specific & automatically generated files #
+#################################################
 composer.lock
+vendor/
+build/
+bin/
+tests/tmp/
+
+# IDE and editor specific files #
+#################################
+/nbproject
+/.idea
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+*.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,36 @@
+dist: trusty
+sudo: false
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
-before_script:
-  - composer install
-  - mkdir build
+env:
+  - LARAVEL_VERSION=5.5.*
+  - LARAVEL_VERSION=5.6.*
 
-script: bin/phpunit
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.0
+      env: LARAVEL_VERSION=5.5.*
 
-after_script:
-  - php bin/coveralls -v
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - travis_retry composer self-update
+  - travis_retry composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
+
+install:
+  - travis_retry composer update --no-interaction --prefer-dist $COMPOSER_ARGS
+
+script:
+  - bin/phpunit
+
+after_success:
+  after_success:
+  - travis_retry composer require php-coveralls/php-coveralls
+  - travis_retry bin/php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@ script:
   - bin/phpunit
 
 after_success:
-  after_success:
   - travis_retry composer require php-coveralls/php-coveralls
   - travis_retry bin/php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![StyleCI](https://styleci.io/repos/96462257/shield?branch=master)](https://styleci.io/repos/96462257)
 [![License](https://poser.pugx.org/ohmybrew/laravel-shopify/license)](https://packagist.org/packages/ohmybrew/laravel-shopify)
 
-A full-featured Laravel package for aiding in Shopify App development, similar to `shopify_app` for Rails. Works for Laravel 5.4-5.6.
+A full-featured Laravel package for aiding in Shopify App development, similar to `shopify_app` for Rails. Works for Laravel 5.5-5.6.
 
 ![Screenshot](https://github.com/ohmybrew/laravel-shopify/raw/master/screenshot.png)
 ![Screenshot: Billable](https://github.com/ohmybrew/laravel-shopify/raw/master/screenshot-billable.png)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require-dev":{
     "orchestra/database": "~3.5",
     "orchestra/testbench": "~3.5",
-    "phpunit/phpunit": "~6.0",
+    "phpunit/phpunit": "~6.0||~7.0",
     "squizlabs/php_codesniffer": "^3.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,13 @@
     "php": ">=7.0.0",
     "laravel/framework": "~5.5",
     "ohmybrew/basic-shopify-api": "~3.0",
-    "doctrine/dbal": "~2.5.0"
+    "doctrine/dbal": "~2.5"
   },
   "require-dev":{
-      "orchestra/database": "~3.5.0",
-      "orchestra/testbench": "~3.5.0",
-      "phpunit/phpunit": "~6.0",
-      "satooshi/php-coveralls": "~1.0",
-      "squizlabs/php_codesniffer": "^3.0"
+    "orchestra/database": "~3.5",
+    "orchestra/testbench": "~3.5",
+    "phpunit/phpunit": "~6.0",
+    "squizlabs/php_codesniffer": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
In this request:
- Remove `.coveralls.yml` file (Coveralls will be corrected with TravisCI automatic)
- Add `.gitattributes` file for line ending (LF) and  exclude `tests` folder when `composer require`
- Update `.gitignore` file for ignoring some IDE and OS files
- Update `.travis.yml` for testing with Laravel 5.5 & 5.6, PHP 7+
- Update `composer.json` for fix some errors with Laravel 5.6
