### PR TITLE
Multi Billing Plan Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ For more information, tutorials, etc., please view the project's [wiki](https://
 - [x] Provide assistance in developing Shopify apps with Laravel
 - [x] Integration with Shopify API
 - [x] Authentication & installation for shops
-- [x] Billing integration built-in for single and recurring application charges
+- [x] Plan & billing integration for single, recurring, and usage-types
 - [x] Tracking charges to a shop (recurring, single, usage, etc) with trial support
 - [x] Auto install app webhooks and scripttags thorugh background jobs
 - [x] Provide basic ESDK views
 - [x] Handles and processes incoming webhooks
 - [x] Handles and verifies incoming app proxy requests
+- [x] Namespacing abilities to run multiple apps on the same database
 
 ## Documentation
 

--- a/src/ShopifyApp/Libraries/BillingPlan.php
+++ b/src/ShopifyApp/Libraries/BillingPlan.php
@@ -2,6 +2,7 @@
 
 namespace OhMyBrew\ShopifyApp\Libraries;
 
+use Exception;
 use OhMyBrew\ShopifyApp\Models\Shop;
 use OhMyBrew\ShopifyApp\Models\Plan;
 
@@ -114,6 +115,12 @@ class BillingPlan
             'price'         => $this->plan->price,
             'return_url'    => secure_url(config('shopify-app.billing_redirect'), ['plan_id' => $this->plan->id]),
         ];
+
+        // Handle capped amounts for UsageCharge API
+        if (isset($this->plan->capped_amount)) {
+            $chargeDetails['capped_amount'] = $this->plan->capped_amount;
+            $chargeDetails['terms'] = $this->plan->terms;
+        }
 
         return $chargeDetails;
     }

--- a/src/ShopifyApp/Libraries/BillingPlan.php
+++ b/src/ShopifyApp/Libraries/BillingPlan.php
@@ -100,6 +100,25 @@ class BillingPlan
     }
 
     /**
+     * Returns the charge params sent with the post request.
+     *
+     * @return array
+     */
+    public function getChargeParams()
+    {
+        // Build the charge array
+        $chargeDetails = [
+            'test'          => $this->plan->isTest(),
+            'trial_days'    => $this->plan->hasTrial() ? $this->plan->trial_days : 0,
+            'name'          => $this->plan->name,
+            'price'         => $this->plan->price,
+            'return_url'    => secure_url(config('shopify-app.billing_redirect'), ['plan_id' => $this->plan->id]),
+        ];
+
+        return $chargeDetails;
+    }
+
+    /**
      * Gets the confirmation URL to redirect the customer to.
      * This URL sends them to Shopify's billing page.
      *
@@ -110,20 +129,11 @@ class BillingPlan
      */
     public function getConfirmationUrl()
     {
-        // Build the charge array
-        $chargeDetails = [
-            'test'          => $this->plan->isTest(),
-            'trial_days'    => $this->plan->hasTrial() ? $this->plan->trial_days : 0,
-            'name'          => $this->plan->name,
-            'price'         => $this->plan->price,
-            'return_url'    => config('shopify-app.billing_redirect'),
-        ];
-
         // Begin the charge request
         $charge = $this->shop->api()->rest(
             'POST',
             "/admin/{$this->plan->typeAsString(true)}.json",
-            ["{$this->plan->typeAsString()}" => $chargeDetails]
+            ["{$this->plan->typeAsString()}" => $this->getChargeParams()]
         )->body->{$this->plan->typeAsString()};
 
         return $charge->confirmation_url;

--- a/src/ShopifyApp/Middleware/AuthWebhook.php
+++ b/src/ShopifyApp/Middleware/AuthWebhook.php
@@ -4,6 +4,7 @@ namespace OhMyBrew\ShopifyApp\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use OhMyBrew\ShopifyApp\Facades\ShopifyApp;
 
 class AuthWebhook
 {

--- a/src/ShopifyApp/Middleware/AuthWebhook.php
+++ b/src/ShopifyApp/Middleware/AuthWebhook.php
@@ -21,8 +21,7 @@ class AuthWebhook
         $shop = request()->header('x-shopify-shop-domain');
         $data = request()->getContent();
 
-        // From https://help.shopify.com/api/getting-started/webhooks#verify-webhook
-        $hmacLocal = base64_encode(hash_hmac('sha256', $data, config('shopify-app.api_secret'), true));
+        $hmacLocal = ShopifyApp::createHmac(['data' => $data, 'raw' => true, 'encode' => true]);
         if (!hash_equals($hmac, $hmacLocal) || empty($shop)) {
             // Issue with HMAC or missing shop header
             abort(401, 'Invalid webhook signature');

--- a/src/ShopifyApp/Middleware/Billable.php
+++ b/src/ShopifyApp/Middleware/Billable.php
@@ -20,18 +20,8 @@ class Billable
     public function handle(Request $request, Closure $next)
     {
         if (config('shopify-app.billing_enabled') === true) {
-            // Grab the shop and last recurring or one-time charge
             $shop = ShopifyApp::shop();
-            $lastCharge = $shop->charges()
-                ->whereIn('type', [Charge::CHARGE_RECURRING, Charge::CHARGE_ONETIME])
-                ->orderBy('created_at', 'desc')
-                ->first();
-
-            if (
-                !$shop->isFreemium() &&
-                !$shop->isGrandfathered() &&
-                (is_null($lastCharge) || $lastCharge->isDeclined() || $lastCharge->isCancelled())
-            ) {
+            if (!$shop->isFreemium() && !$shop->isGrandfathered() && !$shop->plan) {
                 // They're not grandfathered in, and there is no charge or charge was declined... redirect to billing
                 return redirect()->route('billing');
             }

--- a/src/ShopifyApp/Middleware/Billable.php
+++ b/src/ShopifyApp/Middleware/Billable.php
@@ -28,6 +28,7 @@ class Billable
                 ->first();
 
             if (
+                !$shop->isFreemium() &&
                 !$shop->isGrandfathered() &&
                 (is_null($lastCharge) || $lastCharge->isDeclined() || $lastCharge->isCancelled())
             ) {

--- a/src/ShopifyApp/Models/Charge.php
+++ b/src/ShopifyApp/Models/Charge.php
@@ -34,6 +34,16 @@ class Charge extends Model
     }
 
     /**
+     * Gets the plan.
+     *
+     * @return \OhMyBrew\ShopifyApp\Models\Plan
+     */
+    public function plan()
+    {
+        return $this->hasOne('OhMyBrew\ShopifyApp\Models\Plan');
+    }
+
+    /**
      * Gets the charge's data from Shopify.
      *
      * @return object

--- a/src/ShopifyApp/Models/Charge.php
+++ b/src/ShopifyApp/Models/Charge.php
@@ -17,6 +17,32 @@ class Charge extends Model
     const CHARGE_CREDIT = 4;
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'type',
+        'shop_id',
+        'charge_id',
+        'plan_id',
+    ];
+
+    /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'type'          => 'int',
+        'test'          => 'bool',
+        'charge_id'     => 'int',
+        'shop_id'       => 'int',
+        'capped_amount' => 'float',
+        'price'         => 'float',
+    ];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array

--- a/src/ShopifyApp/Models/Charge.php
+++ b/src/ShopifyApp/Models/Charge.php
@@ -40,7 +40,7 @@ class Charge extends Model
      */
     public function plan()
     {
-        return $this->hasOne('OhMyBrew\ShopifyApp\Models\Plan');
+        return $this->belongsTo('OhMyBrew\ShopifyApp\Models\Plan');
     }
 
     /**

--- a/src/ShopifyApp/Models/Plan.php
+++ b/src/ShopifyApp/Models/Plan.php
@@ -11,6 +11,16 @@ class Plan extends Model
     const PLAN_ONETIME = 2;
 
     /**
+     * Get charges.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function charges()
+    {
+        return $this->hasMany('OhMyBrew\ShopifyApp\Models\Charge');
+    }
+
+    /**
      * Returns the plan type as a string (for API).
      *
      * @param bool $plural Return the plural form or not.
@@ -25,7 +35,7 @@ class Plan extends Model
                 $type = 'application_charge';
                 break;
             default:
-            case self:PLAN_RECURRING:
+            case self::PLAN_RECURRING:
                 $type = 'recurring_application_charge';
                 break;
         }

--- a/src/ShopifyApp/Models/Plan.php
+++ b/src/ShopifyApp/Models/Plan.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OhMyBrew\ShopifyApp\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Plan extends Model
+{
+    // Types of plans
+    const PLAN_RECURRING = 1;
+    const PLAN_ONETIME = 2;
+
+    /**
+     * Checks if this plan has a trial.
+     *
+     * @return boolean
+     */
+    public function hasTrial()
+    {
+        return $this->trial_days !== null && $this->trial_days > 0;
+    }
+
+    /**
+     * Checks if this plan should be presented on install.
+     *
+     * @return boolean
+     */
+    public function isOnInstall()
+    {
+        return (bool) $this->on_install;
+    }
+
+    /**
+     * Checks if the plan is a test.
+     *
+     * @return bool
+     */
+    public function isTest()
+    {
+        return (bool) $this->test;
+    }
+}

--- a/src/ShopifyApp/Models/Plan.php
+++ b/src/ShopifyApp/Models/Plan.php
@@ -11,6 +11,29 @@ class Plan extends Model
     const PLAN_ONETIME = 2;
 
     /**
+     * Returns the plan type as a string (for API).
+     *
+     * @param bool $plural Return the plural form or not.
+     *
+     * @return string
+     */
+    public function typeAsString($plural = false)
+    {
+        $type = null;
+        switch ($this->type) {
+            case self::PLAN_ONETIME:
+                $type = 'application_charge';
+                break;
+            default:
+            case self:PLAN_RECURRING:
+                $type = 'recurring_application_charge';
+                break;
+        }
+
+        return $plural ? "{$type}s" : $type;
+    }
+
+    /**
      * Checks if this plan has a trial.
      *
      * @return boolean

--- a/src/ShopifyApp/Models/Plan.php
+++ b/src/ShopifyApp/Models/Plan.php
@@ -11,6 +11,19 @@ class Plan extends Model
     const PLAN_ONETIME = 2;
 
     /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'type'          => 'int',
+        'test'          => 'bool',
+        'on_install'    => 'bool',
+        'capped_amount' => 'float',
+        'price'         => 'float',
+    ];
+
+    /**
      * Get charges.
      *
      * @return \Illuminate\Database\Eloquent\Collection

--- a/src/ShopifyApp/Models/Shop.php
+++ b/src/ShopifyApp/Models/Shop.php
@@ -97,4 +97,24 @@ class Shop extends Model
     {
         return $this->charges->isNotEmpty();
     }
+
+    /**
+     * Gets the plan.
+     *
+     * @return \OhMyBrew\ShopifyApp\Models\Plan
+     */
+    public function plan()
+    {
+        return $this->hasOne('OhMyBrew\ShopifyApp\Models\Plan');
+    }
+
+    /**
+     * Checks if the shop is freemium.
+     *
+     * @return bool
+     */
+    public function isFreemium()
+    {
+        return ((bool) $this->freemium) === true;
+    }
 }

--- a/src/ShopifyApp/Models/Shop.php
+++ b/src/ShopifyApp/Models/Shop.php
@@ -24,6 +24,16 @@ class Shop extends Model
     ];
 
     /**
+     * The attributes that should be casted to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'grandfathered' => 'bool',
+        'freemium'      => 'bool',
+    ];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array

--- a/src/ShopifyApp/Models/Shop.php
+++ b/src/ShopifyApp/Models/Shop.php
@@ -105,7 +105,7 @@ class Shop extends Model
      */
     public function plan()
     {
-        return $this->hasOne('OhMyBrew\ShopifyApp\Models\Plan');
+        return $this->belongsTo('OhMyBrew\ShopifyApp\Models\Plan');
     }
 
     /**

--- a/src/ShopifyApp/Observers/ShopObserver.php
+++ b/src/ShopifyApp/Observers/ShopObserver.php
@@ -20,7 +20,7 @@ class ShopObserver
             $shop->namespace = config('shopify-app.namespace');
         }
 
-        if (config('shopify-app.billing_freemium_enabled') === true) {
+        if (config('shopify-app.billing_freemium_enabled') === true && !isset($shop->freemium)) {
             // Add the freemium flag to the shop
             $shop->freemium = true;
         }

--- a/src/ShopifyApp/Observers/ShopObserver.php
+++ b/src/ShopifyApp/Observers/ShopObserver.php
@@ -19,5 +19,10 @@ class ShopObserver
             // Automatically add the current namespace to new records
             $shop->namespace = config('shopify-app.namespace');
         }
+
+        if (config('shopify-app.billing_freemium_enabled') === true) {
+            // Add the freemium flag to the shop
+            $shop->freemium = true;
+        }
     }
 }

--- a/src/ShopifyApp/ShopifyApp.php
+++ b/src/ShopifyApp/ShopifyApp.php
@@ -97,6 +97,7 @@ class ShopifyApp
      * HMAC creation helper.
      *
      * @param array $opts
+     *
      * @return string
      */
     public function createHmac(array $opts)

--- a/src/ShopifyApp/ShopifyApp.php
+++ b/src/ShopifyApp/ShopifyApp.php
@@ -92,4 +92,36 @@ class ShopifyApp
         // Return the host after cleaned up
         return parse_url("http://{$domain}", PHP_URL_HOST);
     }
+
+    /**
+     * HMAC creation helper.
+     *
+     * @param array $opts
+     * @return string
+     */
+    public function createHmac(array $opts)
+    {
+        // Setup defaults
+        $data = $opts['data'];
+        $raw = $opts['raw'] ?? false;
+        $buildQuery = $opts['buildQuery'] ?? false;
+        $encode = $opts['encode'] ?? false;
+        $secret = $opts['secret'] ?? config('shopify-app.api_secret');
+
+        if ($buildQuery) {
+            //Query params must be sorted and compiled
+            ksort($data);
+            $queryCompiled = [];
+            foreach ($data as $key => $value) {
+                $queryCompiled[] = "{$key}=".(is_array($value) ? implode($value, ',') : $value);
+            }
+            $data = implode($queryCompiled, '');
+        }
+
+        // Create the hmac all based on the secret
+        $hmac = hash_hmac('sha256', $data, $secret, $raw);
+
+        // Return based on options
+        return $encode ? base64_encode($hmac) : $hmac;
+    }
 }

--- a/src/ShopifyApp/Traits/BillingControllerTrait.php
+++ b/src/ShopifyApp/Traits/BillingControllerTrait.php
@@ -90,9 +90,7 @@ trait BillingControllerTrait
 
         if ($status === 'declined') {
             // Show the error... don't allow access
-            return view('shopify-app::billing.error', [
-                'message' => 'It seems you have declined the billing charge for this application'
-            ]);
+            return view('shopify-app::billing.error', ['message' => 'It seems you have declined the billing charge for this application']);
         }
 
         // All good, update the shop's plan and take them off freeium (if applicable)

--- a/src/ShopifyApp/Traits/BillingControllerTrait.php
+++ b/src/ShopifyApp/Traits/BillingControllerTrait.php
@@ -134,8 +134,10 @@ trait BillingControllerTrait
             'POST',
             "/admin/recurring_application_charges/{$lastCharge->charge_id}/usage_charges.json",
             [
-                'price'       => $data['price'],
-                'description' => $data['description'],
+                'usage_charge' => [
+                    'price'       => $data['price'],
+                    'description' => $data['description'],
+                ],
             ]
         )->body->usage_charge;
 

--- a/src/ShopifyApp/Traits/BillingControllerTrait.php
+++ b/src/ShopifyApp/Traits/BillingControllerTrait.php
@@ -185,6 +185,7 @@ trait BillingControllerTrait
     {
         return $shop->charges()
             ->whereIn('type', [Charge::CHARGE_RECURRING, Charge::CHARGE_ONETIME])
+            ->where('plan_id', $shop->plan_id)
             ->orderBy('created_at', 'desc')
             ->first();
     }

--- a/src/ShopifyApp/Traits/BillingControllerTrait.php
+++ b/src/ShopifyApp/Traits/BillingControllerTrait.php
@@ -121,7 +121,7 @@ trait BillingControllerTrait
         }
 
         // Get the input values needed
-        $data = request()->only(['price', 'description', 'signature']);
+        $data = request()->only(['price', 'description', 'redirect', 'signature']);
         $signature = $data['signature'];
         unset($data['signature']);
         ksort($data);
@@ -162,7 +162,7 @@ trait BillingControllerTrait
         $charge->save();
 
         // All done, return with success
-        return redirect()->back()->with('succes', true);
+        return isset($data['redirect']) ? redirect($data['redirect']) : redirect()->back()->with('success', true);
     }
 
     /**

--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -130,60 +130,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Billing Type
+    | Enable Freemium Mode
     |--------------------------------------------------------------------------
     |
-    | Single charge or recurring charge.
-    | Simply use "single" for single, and "recurring" for recurring.
+    | Allow a shop use the app in "freemium" mode.
+    | Shop will get a `freemium` flag on their record in the table.
     |
     */
 
-    'billing_type' => env('SHOPIFY_BILLING_TYPE', 'recurring'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Plan Name
-    |--------------------------------------------------------------------------
-    |
-    | The name of the plan which shows on the billing.
-    |
-    */
-
-    'billing_plan' => env('SHOPIFY_BILLING_PLAN_NAME', 'Base Plan'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Price
-    |--------------------------------------------------------------------------
-    |
-    | The single or recurring price to charge the customer.
-    |
-    */
-
-    'billing_price' => (float) env('SHOPIFY_BILLING_PRICE', 0.00),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Trial
-    |--------------------------------------------------------------------------
-    |
-    | Trails days for the app. Set to 0 for no trial period.
-    |
-    */
-
-    'billing_trial_days' => (int) env('SHOPIFY_BILLING_TRIAL_DAYS', 7),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Test
-    |--------------------------------------------------------------------------
-    |
-    | Enable or disable test mode for billing.
-    | This is useful for development purposes, see Shopify's documentation.
-    |
-    */
-
-    'billing_test' => (bool) env('SHOPIFY_BILLING_TEST', false),
+    'billing_freemium_enabled' => (bool) env('SHOPIFY_BILLING_FREEMIUM_ENABLED', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -196,28 +151,6 @@ return [
     */
 
     'billing_redirect' => env('SHOPIFY_BILLING_REDIRECT', '/billing/process'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Capped Amount
-    |--------------------------------------------------------------------------
-    |
-    | The capped price for charging a customer when using the UsageCharge API.
-    |
-    */
-
-    'billing_capped_amount' => env('SHOPIFY_BILLING_CAPPED_AMOUNT'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Billing Terms
-    |--------------------------------------------------------------------------
-    |
-    | Terms for the usage. Required if using capped amount.
-    |
-    */
-
-    'billing_terms' => env('SHOPIFY_BILLING_TERMS'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
@@ -13,7 +13,7 @@ class CreatePlansTable extends Migration
      */
     public function up()
     {
-        Schema::create('plan', function (Blueprint $table) {
+        Schema::create('plans', function (Blueprint $table) {
             $table->increments('id');
 
             // The type of plan, either Plan::CHARGE_RECURRING (1) or Plan::CHARGE_ONETIME (2)
@@ -24,6 +24,12 @@ class CreatePlansTable extends Migration
 
             // Price of the plan
             $table->decimal('price', 8, 2);
+
+            // Store the amount of the charge, this helps if you are experimenting with pricing
+            $table->decimal('capped_amount', 8, 2)->nullable();
+
+            // Terms for the usage charges
+            $table->string('terms')->nullable();
 
             // Nullable in case of 0 trial days
             $table->integer('trial_days')->nullable();

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePlansTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('plan', function (Blueprint $table) {
+            $table->increments('id');
+
+            // The type of plan, either Charge::CHARGE_RECURRING (1) or Charge::CHARGE_ONETIME (2)
+            $table->integer('type');
+
+            // Name of the plan
+            $table->string('name');
+
+            // Price of the plan
+            $table->decimal('price', 8, 2);
+
+            // Nullable in case of 0 trial days
+            $table->integer('trial_days')->nullable();
+
+            // Is a test plan or not
+            $table->boolean('test')->default(false);
+
+            // On-install
+            $table->boolean('on_install')->default(false);
+
+            // Provides created_at && updated_at columns
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('plans');
+    }
+}

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_153154_create_plans_table.php
@@ -16,7 +16,7 @@ class CreatePlansTable extends Migration
         Schema::create('plan', function (Blueprint $table) {
             $table->increments('id');
 
-            // The type of plan, either Charge::CHARGE_RECURRING (1) or Charge::CHARGE_ONETIME (2)
+            // The type of plan, either Plan::CHARGE_RECURRING (1) or Plan::CHARGE_ONETIME (2)
             $table->integer('type');
 
             // Name of the plan

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePlansTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('charges', function (Blueprint $table) {
+            // Linking
+            $table->integer('plan_id')->unsigned();
+            $table->foreign('plan_id')->references('id')->on('plans');
+        });
+
+        Schema::create('shops', function (Blueprint $table) {
+            // Linking
+            $table->integer('plan_id')->unsigned();
+            $table->foreign('plan_id')->references('id')->on('plans');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('charges', function (Blueprint $table) {
+            $table->dropForeign(['plan_id']);
+        });
+
+        Schema::table('shops', function (Blueprint $table) {
+            $table->dropForeign(['plan_id']);
+        });
+    }
+}

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
@@ -13,15 +13,15 @@ class AddPlanToShopsTableAndChargesTable extends Migration
      */
     public function up()
     {
-        Schema::create('charges', function (Blueprint $table) {
+        Schema::table('charges', function (Blueprint $table) {
             // Linking
-            $table->integer('plan_id')->unsigned();
+            $table->integer('plan_id')->unsigned()->nullable();
             $table->foreign('plan_id')->references('id')->on('plans');
         });
 
-        Schema::create('shops', function (Blueprint $table) {
+        Schema::table('shops', function (Blueprint $table) {
             // Linking
-            $table->integer('plan_id')->unsigned();
+            $table->integer('plan_id')->unsigned()->nullable();
             $table->foreign('plan_id')->references('id')->on('plans');
         });
     }
@@ -34,11 +34,11 @@ class AddPlanToShopsTableAndChargesTable extends Migration
     public function down()
     {
         Schema::table('charges', function (Blueprint $table) {
-            $table->dropForeign(['plan_id']);
+            $table->dropColumn(['plan_id']);
         });
 
         Schema::table('shops', function (Blueprint $table) {
-            $table->dropForeign(['plan_id']);
+            $table->dropColumn(['plan_id']);
         });
     }
 }

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_154001_add_plan_to_shops_table_and_charges_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePlansTable extends Migration
+class AddPlanToShopsTableAndChargesTable extends Migration
 {
     /**
      * Run the migrations.

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_154502_add_freemium_flag_to_shops_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_154502_add_freemium_flag_to_shops_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFreemiumToShopsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shops', function (Blueprint $table) {
+            $table->boolean('freemium')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shops', function (Blueprint $table) {
+            $table->dropColumn(['freemium']);
+        });
+    }
+}

--- a/src/ShopifyApp/resources/database/migrations/2018_08_31_154502_add_freemium_flag_to_shops_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_08_31_154502_add_freemium_flag_to_shops_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddFreemiumToShopsTable extends Migration
+class AddFreemiumFlagToShopsTable extends Migration
 {
     /**
      * Run the migrations.

--- a/src/ShopifyApp/resources/database/migrations/2018_09_11_101333_add_usage_charge_support_to_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_09_11_101333_add_usage_charge_support_to_charges_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUsageChargeSupportToChargesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('charges', function (Blueprint $table) {
+            // Description support
+            $table->string('description')->nullable();
+
+            // Linking
+            $table->integer('reference_charge')->unsigned()->nullable();
+            $table->foreign('reference_charge')->references('charge_id')->on('charges')->onDelete('cascade');
+        });
+    }
+}

--- a/src/ShopifyApp/resources/database/migrations/2018_09_11_101333_add_usage_charge_support_to_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_09_11_101333_add_usage_charge_support_to_charges_table.php
@@ -17,8 +17,12 @@ class AddUsageChargeSupportToChargesTable extends Migration
             // Description support
             $table->string('description')->nullable();
 
-            // Linking
-            $table->integer('reference_charge')->unsigned()->nullable();
+            // Linking to charge_id
+            $table->bigInteger('reference_charge')->nullable();
+        });
+
+        Schema::table('charges', function (Blueprint $table) {
+            // Linking to charge_id, seperate schema block due to contraint issue
             $table->foreign('reference_charge')->references('charge_id')->on('charges')->onDelete('cascade');
         });
     }

--- a/src/ShopifyApp/resources/database/migrations/2018_09_12_101645_add_default_to_test_on_charges_table.php
+++ b/src/ShopifyApp/resources/database/migrations/2018_09_12_101645_add_default_to_test_on_charges_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDefaultToTestOnChargesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('charges', function (Blueprint $table) {
+            $table->boolean('test')->default(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('charges', function (Blueprint $table) {
+            $table->boolean('test')->default(null)->change();
+        });
+    }
+}

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -86,6 +86,22 @@ Route::group(['middleware' => ['web']], function () {
         'OhMyBrew\ShopifyApp\Controllers\BillingController@process'
     )
     ->name('billing.process');
+
+    /*
+    |--------------------------------------------------------------------------
+    | Billing Processor for Usage Charges
+    |--------------------------------------------------------------------------
+    |
+    | Creates a usage charge on a recurring charge.
+    |
+    */
+
+    Route::match(
+        ['get', 'post'],
+        '/billing/usage-charge',
+        'OhMyBrew\ShopifyApp\Controllers\BillingController@usageCharge'
+    )
+    ->name('billing.usage_charge');
 });
 
 Route::group(['middleware' => ['api']], function () {

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -67,7 +67,7 @@ Route::group(['middleware' => ['web']], function () {
     */
 
     Route::get(
-        '/billing',
+        '/billing/{planId?}',
         'OhMyBrew\ShopifyApp\Controllers\BillingController@index'
     )
     ->name('billing');
@@ -82,7 +82,7 @@ Route::group(['middleware' => ['web']], function () {
     */
 
     Route::get(
-        '/billing/process',
+        '/billing/process/{planId?}',
         'OhMyBrew\ShopifyApp\Controllers\BillingController@process'
     )
     ->name('billing.process');

--- a/src/ShopifyApp/resources/routes.php
+++ b/src/ShopifyApp/resources/routes.php
@@ -70,6 +70,7 @@ Route::group(['middleware' => ['web']], function () {
         '/billing/{planId?}',
         'OhMyBrew\ShopifyApp\Controllers\BillingController@index'
     )
+    ->where('planId', '^([0-9]+|)$')
     ->name('billing');
 
     /*
@@ -85,6 +86,7 @@ Route::group(['middleware' => ['web']], function () {
         '/billing/process/{planId?}',
         'OhMyBrew\ShopifyApp\Controllers\BillingController@process'
     )
+    ->where('planId', '^([0-9]+|)$')
     ->name('billing.process');
 
     /*

--- a/src/ShopifyApp/resources/views/billing/error.blade.php
+++ b/src/ShopifyApp/resources/views/billing/error.blade.php
@@ -1,0 +1,11 @@
+@extends('shopify-app::layouts.error')
+
+@section('content')
+    <div class="flex-center position-ref full-height">
+        <div class="content">
+            <div class="title m-b-md">Oops!</div>
+                <p>{{ message }}</p>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/src/ShopifyApp/resources/views/billing/error.blade.php
+++ b/src/ShopifyApp/resources/views/billing/error.blade.php
@@ -4,7 +4,7 @@
     <div class="flex-center position-ref full-height">
         <div class="content">
             <div class="title m-b-md">Oops!</div>
-                <p>{{ message }}</p>
+                <p>{{ $message }}</p>
             </div>
         </div>
     </div>

--- a/src/ShopifyApp/resources/views/layouts/error.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/error.blade.php
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Oops! | 403</title>
+        <title>Oops!</title>
 
         <link href="https://fonts.googleapis.com/css?family=Raleway:100,600" rel="stylesheet" type="text/css">
 
@@ -56,12 +56,7 @@
         <div class="app-wrapper">
             <div class="app-content">
                 <main role="main">
-                    <div class="flex-center position-ref full-height">
-                        <div class="content">
-                            <div class="title m-b-md">Oops!</div>
-                            <p>{{ $exception->getMessage() }}</p>
-                        </div>
-                    </div>
+                    @yield('content')
                 </main>
             </div>
         </div>

--- a/tests/Controllers/BillingControllerTest.php
+++ b/tests/Controllers/BillingControllerTest.php
@@ -5,6 +5,7 @@ namespace OhMyBrew\ShopifyApp\Test\Controllers;
 use Carbon\Carbon;
 use OhMyBrew\ShopifyApp\Controllers\BillingController;
 use OhMyBrew\ShopifyApp\Models\Charge;
+use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Models\Shop;
 use OhMyBrew\ShopifyApp\Test\Stubs\ApiStub;
 use OhMyBrew\ShopifyApp\Test\TestCase;
@@ -43,7 +44,7 @@ class BillingControllerTest extends TestCase
         $oldCharge = $shop->charges()->whereIn('type', [Charge::CHARGE_RECURRING, Charge::CHARGE_ONETIME])->orderBy('created_at', 'desc')->first();
 
         // Run with a new charge
-        $response = $this->call('get', '/billing/process', ['charge_id' => $chargeId]);
+        $response = $this->call('get', '/billing/process/1', ['charge_id' => $chargeId]);
 
         // Get the new charge and refresh the old one
         $newCharge = $shop->charges()->get()->last();
@@ -57,7 +58,7 @@ class BillingControllerTest extends TestCase
     public function testShopDeclinesBilling()
     {
         $shop = Shop::where('shopify_domain', 'example.myshopify.com')->first();
-        $response = $this->call('get', '/billing/process', ['charge_id' => 10292]);
+        $response = $this->call('get', '/billing/process/1', ['charge_id' => 10292]);
         $lastCharge = $shop->charges()->get()->last();
 
         $response->assertStatus(403);
@@ -69,93 +70,27 @@ class BillingControllerTest extends TestCase
         );
     }
 
-    public function testReturnsBasePlanDetails()
+    public function testReturnOnInstallFlaggedPlan()
     {
         $controller = new BillingController();
-        $method = new ReflectionMethod(BillingController::class, 'planDetails');
+        $method = new ReflectionMethod(BillingController::class, 'getPlan');
         $method->setAccessible(true);
 
         // Based on default config
         $this->assertEquals(
-            [
-                'name'       => config('shopify-app.billing_plan'),
-                'price'      => config('shopify-app.billing_price'),
-                'test'       => config('shopify-app.billing_test'),
-                'trial_days' => config('shopify-app.billing_trial_days'),
-                'return_url' => url(config('shopify-app.billing_redirect')),
-            ],
-            $method->invoke($controller, $this->shop)
+            Plan::find(1),
+            $method->invoke($controller, null)
         );
     }
 
-    public function testReturnsBasePlanDetailsWithUsage()
+    public function testReturnPlanPassedToController()
     {
-        config(['shopify-app.billing_capped_amount' => 100.00]);
-        config(['shopify-app.billing_terms' => '$1 for 100 emails.']);
-
         $controller = new BillingController();
-        $method = new ReflectionMethod(BillingController::class, 'planDetails');
+        $method = new ReflectionMethod(BillingController::class, 'getPlan');
         $method->setAccessible(true);
 
         // Based on default config
-        $this->assertEquals(
-            [
-                'name'          => config('shopify-app.billing_plan'),
-                'price'         => config('shopify-app.billing_price'),
-                'test'          => config('shopify-app.billing_test'),
-                'trial_days'    => config('shopify-app.billing_trial_days'),
-                'capped_amount' => config('shopify-app.billing_capped_amount'),
-                'terms'         => config('shopify-app.billing_terms'),
-                'return_url'    => url(config('shopify-app.billing_redirect')),
-            ],
-            $method->invoke($controller, $this->shop)
-        );
-    }
-
-    public function testReturnsBasePlanDetailsChangedByCancelledCharge()
-    {
-        $shop = new Shop();
-        $shop->shopify_domain = 'test-cancelled-shop.myshopify.com';
-        $shop->save();
-
-        $charge = new Charge();
-        $charge->charge_id = 267921978;
-        $charge->test = false;
-        $charge->name = 'Base Plan Cancelled';
-        $charge->status = 'cancelled';
-        $charge->type = 1;
-        $charge->price = 25.00;
-        $charge->trial_days = 7;
-        $charge->trial_ends_on = Carbon::today()->addWeeks(1)->format('Y-m-d');
-        $charge->cancelled_on = Carbon::today()->addDays(2)->format('Y-m-d');
-        $charge->shop_id = $shop->id;
-        $charge->save();
-
-        $controller = new BillingController();
-        $method = new ReflectionMethod(BillingController::class, 'planDetails');
-        $method->setAccessible(true);
-
-        // Based on default config
-        $this->assertEquals(
-            [
-                'name'       => config('shopify-app.billing_plan'),
-                'price'      => config('shopify-app.billing_price'),
-                'test'       => config('shopify-app.billing_test'),
-                'trial_days' => 5,
-                'return_url' => url(config('shopify-app.billing_redirect')),
-            ],
-            $method->invoke($controller, $shop)
-        );
-    }
-
-    public function testReturnsBaseChargeType()
-    {
-        $controller = new BillingController();
-        $method = new ReflectionMethod(BillingController::class, 'chargeType');
-        $method->setAccessible(true);
-
-        // Based on default config
-        $this->assertEquals(config('shopify-app.billing_type'), $method->invoke($controller));
+        $this->assertEquals(Plan::find(2), $method->invoke($controller, 2));
     }
 
     public function testReturnsLastChargeForShop()

--- a/tests/Controllers/BillingControllerTest.php
+++ b/tests/Controllers/BillingControllerTest.php
@@ -2,14 +2,14 @@
 
 namespace OhMyBrew\ShopifyApp\Test\Controllers;
 
+use Carbon\Carbon;
 use OhMyBrew\ShopifyApp\Controllers\BillingController;
 use OhMyBrew\ShopifyApp\Models\Charge;
 use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Models\Shop;
+use OhMyBrew\ShopifyApp\ShopifyApp;
 use OhMyBrew\ShopifyApp\Test\Stubs\ApiStub;
 use OhMyBrew\ShopifyApp\Test\TestCase;
-use Carbon\Carbon;
-use OhMyBrew\ShopifyApp\ShopifyApp;
 use ReflectionMethod;
 
 class BillingControllerTest extends TestCase
@@ -26,7 +26,7 @@ class BillingControllerTest extends TestCase
 
         // Base shop for all tests here
         $this->shop = Shop::where('shopify_domain', 'example.myshopify.com')->first();
-        session(['shopify_domain' => $this->shop->shopify_domain]); 
+        session(['shopify_domain' => $this->shop->shopify_domain]);
     }
 
     public function testSendsShopToBillingScreen()

--- a/tests/Controllers/HomeControllerTest.php
+++ b/tests/Controllers/HomeControllerTest.php
@@ -35,7 +35,6 @@ class HomeControllerTest extends TestCase
 
     public function testShopWithSessionShouldLoad()
     {
-
         $response = $this->get('/');
 
         $response->assertStatus(200);

--- a/tests/Controllers/HomeControllerTest.php
+++ b/tests/Controllers/HomeControllerTest.php
@@ -20,8 +20,8 @@ class HomeControllerTest extends TestCase
 
     public function testNoShopSessionShouldRedirectToAuthenticate()
     {
-       // Kill the session
-       session()->forget('shopify_domain');
+        // Kill the session
+        session()->forget('shopify_domain');
 
         $response = $this->call('get', '/', ['shop' => 'example.myshopify.com']);
         $this->assertTrue(strpos($response->content(), 'Redirecting to http://localhost/authenticate') !== false);

--- a/tests/Controllers/HomeControllerTest.php
+++ b/tests/Controllers/HomeControllerTest.php
@@ -13,37 +13,44 @@ class HomeControllerTest extends TestCase
 
         // Stub in our API class
         config(['shopify-app.api_class' => new ApiStub()]);
+
+        // Shop for all tests
+        session(['shopify_domain' => 'example.myshopify.com']);
     }
 
     public function testNoShopSessionShouldRedirectToAuthenticate()
     {
+       // Kill the session
+       session()->forget('shopify_domain');
+
         $response = $this->call('get', '/', ['shop' => 'example.myshopify.com']);
-        $this->assertEquals(true, strpos($response->content(), 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($response->content(), 'Redirecting to http://localhost/authenticate') !== false);
     }
 
     public function testWithMismatchedShopsShouldRedirectToAuthenticate()
     {
-        session(['shopify_domain' => 'example.myshopify.com']);
         $response = $this->call('get', '/', ['shop' => 'example-different-shop.myshopify.com']);
-        $this->assertEquals(true, strpos($response->content(), 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($response->content(), 'Redirecting to http://localhost/authenticate') !== false);
     }
 
     public function testShopWithSessionShouldLoad()
     {
-        session(['shopify_domain' => 'example.myshopify.com']);
+
         $response = $this->get('/');
+
         $response->assertStatus(200);
-        $this->assertEquals(true, strpos($response->content(), "apiKey: ''") !== false);
-        $this->assertEquals(true, strpos($response->content(), "shopOrigin: 'https://example.myshopify.com'") !== false);
+        $this->assertTrue(strpos($response->content(), "apiKey: ''") !== false);
+        $this->assertTrue(strpos($response->content(), "shopOrigin: 'https://example.myshopify.com'") !== false);
     }
 
     public function testShopWithSessionAndDisabledEsdkShouldLoad()
     {
-        session(['shopify_domain' => 'example.myshopify.com']);
+        // Tuen off ESDK
         config(['shopify-app.esdk_enabled' => false]);
 
         $response = $this->get('/');
+
         $response->assertStatus(200);
-        $this->assertEquals(false, strpos($response->content(), 'ShopifyApp.init'));
+        $this->assertFalse(strpos($response->content(), 'ShopifyApp.init'));
     }
 }

--- a/tests/Jobs/AppUninstalledJobTest.php
+++ b/tests/Jobs/AppUninstalledJobTest.php
@@ -20,6 +20,7 @@ class AppUninstalledJobTest extends TestCase
         $this->shop->shopify_domain = 'example-isolated.myshopify.com';
         $this->shop->save();
 
+        // Get the data
         $this->data = json_decode(file_get_contents(__DIR__.'/../fixtures/app_uninstalled.json'));
     }
 
@@ -84,6 +85,6 @@ class AppUninstalledJobTest extends TestCase
     public function testJobDoesNothingForUnknownShop()
     {
         $job = new AppUninstalledJob('unknown-shop.myshopify.com', null);
-        $this->assertEquals(false, $job->handle());
+        $this->assertFalse($job->handle());
     }
 }

--- a/tests/Libraries/BillingPlanTest.php
+++ b/tests/Libraries/BillingPlanTest.php
@@ -65,7 +65,7 @@ class BillingPlanTest extends TestCase
     {
         $response = (new BillingPlan($this->shop, Plan::find(1)))->setChargeId(1029266947)->activate();
 
-        $this->assertEquals(true, is_object($response));
+        $this->assertTrue(is_object($response));
         $this->assertEquals('active', $response->status);
     }
 
@@ -82,7 +82,7 @@ class BillingPlanTest extends TestCase
     {
         $response = (new BillingPlan($this->shop, Plan::find(1)))->setChargeId(1029266947)->getCharge();
 
-        $this->assertEquals(true, is_object($response));
+        $this->assertTrue(is_object($response));
         $this->assertEquals('accepted', $response->status);
     }
 

--- a/tests/Libraries/BillingPlanTest.php
+++ b/tests/Libraries/BillingPlanTest.php
@@ -4,6 +4,7 @@ namespace OhMyBrew\ShopifyApp\Test\Libraries;
 
 use OhMyBrew\ShopifyApp\Libraries\BillingPlan;
 use OhMyBrew\ShopifyApp\Models\Shop;
+use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Test\Stubs\ApiStub;
 use OhMyBrew\ShopifyApp\Test\TestCase;
 
@@ -16,52 +17,53 @@ class BillingPlanTest extends TestCase
         // Stub in our API class
         config(['shopify-app.api_class' => new ApiStub()]);
 
-        // Base shop and plan
+        // Base shop to use
         $this->shop = Shop::find(1);
-        $this->plan = [
-            'name'       => 'Basic Plan',
-            'price'      => 3.00,
-            'trial_days' => 0,
-            'return_url' => 'http://example.com/',
-        ];
     }
 
     public function testShouldReturnConfirmationUrl()
     {
-        $url = (new BillingPlan($this->shop))->setDetails($this->plan)->getConfirmationUrl();
-
         $this->assertEquals(
             'https://example.myshopify.com/admin/charges/1029266947/confirm_recurring_application_charge?signature=BAhpBANeWT0%3D--64de8739eb1e63a8f848382bb757b20343eb414f',
-            $url
+            (new BillingPlan($this->shop, Plan::find(1)))->getConfirmationUrl()
         );
     }
 
     public function testShouldReturnConfirmationUrlWhenUsageIsEnabled()
     {
-        $plan = array_merge($this->plan, [
-            'capped_amount' => 100.00,
-            'terms'         => '$1 for 500 emails',
-        ]);
-        $url = (new BillingPlan($this->shop))->setDetails($plan)->getConfirmationUrl();
-
         $this->assertEquals(
-            'https://example.myshopify.com/admin/charges/1029266947/confirm_recurring_application_charge?signature=BAhpBANeWT0%3D--64de8739eb1e63a8f848382bb757b20343eb414f',
-            $url
+            'https://example.myshopify.com/admin/charges/1017262355/confirm_application_charge?signature=BAhpBBMxojw%3D--1139a82a3433b1a6771786e03f02300440e11883',
+            (new BillingPlan($this->shop, Plan::find(3)))->getConfirmationUrl()
         );
     }
 
     /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Plan details are missing for confirmation URL request.
+     * @expectedException \ArgumentCountError
      */
-    public function testShouldNotReturnConfirmationUrlAndThrowException()
+    public function testShouldThrowExceptionForMissingPlan()
     {
-        (new BillingPlan($this->shop))->getConfirmationUrl();
+        new BillingPlan($this->shop);
+    }
+
+    public function testShouldReturnChargeParams()
+    {
+        $this->assertEquals(
+            [
+                'test'          => false,
+                'trial_days'    => '7',
+                'name'          => 'Capped Plan',
+                'price'         => '5',
+                'return_url'    => secure_url(config('shopify-app.billing_redirect'), ['plan_id' => 4]),
+                'capped_amount' => '100',
+                'terms'         => '$1 for 500 emails',
+            ],
+            (new BillingPlan($this->shop, Plan::find(4)))->getChargeParams()
+        );
     }
 
     public function testShouldActivatePlan()
     {
-        $response = (new BillingPlan($this->shop))->setChargeId(1029266947)->activate();
+        $response = (new BillingPlan($this->shop, Plan::find(1)))->setChargeId(1029266947)->activate();
 
         $this->assertEquals(true, is_object($response));
         $this->assertEquals('active', $response->status);
@@ -73,12 +75,12 @@ class BillingPlanTest extends TestCase
      */
     public function testShouldNotActivatePlanAndThrowException()
     {
-        (new BillingPlan($this->shop))->activate();
+        (new BillingPlan($this->shop, Plan::find(1)))->activate();
     }
 
     public function testShouldGetChargeDetails()
     {
-        $response = (new BillingPlan($this->shop))->setChargeId(1029266947)->getCharge();
+        $response = (new BillingPlan($this->shop, Plan::find(1)))->setChargeId(1029266947)->getCharge();
 
         $this->assertEquals(true, is_object($response));
         $this->assertEquals('accepted', $response->status);
@@ -90,6 +92,6 @@ class BillingPlanTest extends TestCase
      */
     public function testShouldNotGetChargeDetailsAndThrowException()
     {
-        (new BillingPlan($this->shop))->getCharge();
+        (new BillingPlan($this->shop, Plan::find(1)))->getCharge();
     }
 }

--- a/tests/Middleware/AuthProxyMiddlewareTest.php
+++ b/tests/Middleware/AuthProxyMiddlewareTest.php
@@ -32,6 +32,7 @@ class AuthProxyMiddlewareTest extends TestCase
      */
     public function testDenysForMissingShop()
     {
+        // Remove shop from params
         $query = $this->queryParams;
         unset($query['shop']);
         Input::merge($query);
@@ -42,7 +43,7 @@ class AuthProxyMiddlewareTest extends TestCase
             $called = true;
         });
 
-        $this->assertEquals(false, $called);
+        $this->assertFalse($called);
     }
 
     public function testRuns()
@@ -50,7 +51,7 @@ class AuthProxyMiddlewareTest extends TestCase
         Input::merge($this->queryParams);
 
         // Confirm no shop
-        $this->assertEquals(null, session('shopify_domain'));
+        $this->assertNull(session('shopify_domain'));
 
         $called = false;
         (new AuthProxy())->handle(request(), function ($request) use (&$called) {
@@ -66,7 +67,7 @@ class AuthProxyMiddlewareTest extends TestCase
         });
 
         // Confirm full run
-        $this->assertEquals(true, $called);
+        $this->assertTrue($called);
     }
 
     /**
@@ -75,6 +76,7 @@ class AuthProxyMiddlewareTest extends TestCase
      */
     public function testDoesNotRunForInvalidSignature()
     {
+        // Make the signature invalid
         $query = $this->queryParams;
         $query['oops'] = 'i-did-it-again';
         Input::merge($query);
@@ -85,6 +87,6 @@ class AuthProxyMiddlewareTest extends TestCase
             $called = true;
         });
 
-        $this->assertEquals(false, $called);
+        $this->assertFalse($called);
     }
 }

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -17,7 +17,7 @@ class AuthShopMiddlewareTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
     }
 
     public function testShopHasWithAccessShouldPassMiddleware()
@@ -31,7 +31,7 @@ class AuthShopMiddlewareTest extends TestCase
             $called = true;
         });
 
-        $this->assertEquals(true, $called);
+        $this->assertTrue($called);
     }
 
     public function testShopWithNoTokenShouldNotPassMiddleware()
@@ -46,7 +46,7 @@ class AuthShopMiddlewareTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
     }
 
     public function testShopTrashedShouldNotPassMiddleware()
@@ -61,7 +61,7 @@ class AuthShopMiddlewareTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
     }
 
     public function testShopsWhichDoNotMatchShouldKillSessionAndDirectToReAuthenticate()
@@ -129,6 +129,6 @@ class AuthShopMiddlewareTest extends TestCase
 
         $this->assertFalse($called);
         $this->assertEquals('http://localhost/orders', session('return_to'));
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/authenticate') !== false);
     }
 }

--- a/tests/Middleware/AuthWebhookMiddlewareTest.php
+++ b/tests/Middleware/AuthWebhookMiddlewareTest.php
@@ -30,13 +30,16 @@ class AuthWebhookMiddlewareTest extends TestCase
     {
         request()->header('x-shopify-shop-domain', 'example.myshopify.com');
         (new AuthWebhook())->handle(request(), function ($request) {
+            // ...
         });
     }
 
     public function testRuns()
     {
+        // Fake the queue
         Queue::fake();
 
+        // Run the call with our owm mocked Shopify headers and data
         $response = $this->call(
             'post',
             '/webhook/orders-create',
@@ -50,13 +53,16 @@ class AuthWebhookMiddlewareTest extends TestCase
             ],
             file_get_contents(__DIR__.'/../fixtures/webhook.json')
         );
+
         $response->assertStatus(201);
     }
 
     public function testInvalidHmacWontRun()
     {
+        // Fake the data
         Queue::fake();
 
+        // Run the call with our owm mocked Shopify headers and data
         $response = $this->call(
             'post',
             '/webhook/orders-create',
@@ -70,6 +76,7 @@ class AuthWebhookMiddlewareTest extends TestCase
             ],
             file_get_contents(__DIR__.'/../fixtures/webhook.json').'invalid'
         );
+
         $response->assertStatus(401);
     }
 }

--- a/tests/Middleware/BillableMiddlewareTest.php
+++ b/tests/Middleware/BillableMiddlewareTest.php
@@ -20,7 +20,7 @@ class BillableMiddlewareTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/billing') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/billing') !== false);
     }
 
     public function testEnabledBillingWithShopWhoDeclinedCharges()
@@ -36,7 +36,7 @@ class BillableMiddlewareTest extends TestCase
         });
 
         $this->assertFalse($called);
-        $this->assertEquals(true, strpos($result, 'Redirecting to http://localhost/billing') !== false);
+        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/billing') !== false);
     }
 
     public function testEnabledBillingWithPaidShop()

--- a/tests/Middleware/BillableMiddlewareTest.php
+++ b/tests/Middleware/BillableMiddlewareTest.php
@@ -23,22 +23,6 @@ class BillableMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result, 'Redirecting to http://localhost/billing') !== false);
     }
 
-    public function testEnabledBillingWithShopWhoDeclinedCharges()
-    {
-        // Enable billing and set a shop
-        config(['shopify-app.billing_enabled' => true]);
-        session(['shopify_domain' => 'trashed-shop.myshopify.com']);
-
-        $called = false;
-        $result = (new Billable())->handle(request(), function ($request) use (&$called) {
-            // Should never be called
-            $called = true;
-        });
-
-        $this->assertFalse($called);
-        $this->assertTrue(strpos($result, 'Redirecting to http://localhost/billing') !== false);
-    }
-
     public function testEnabledBillingWithPaidShop()
     {
         // Enable billing and set a shop

--- a/tests/Middleware/BillableMiddlewareTest.php
+++ b/tests/Middleware/BillableMiddlewareTest.php
@@ -69,6 +69,21 @@ class BillableMiddlewareTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function testEnabledBillingWithFreemiumShop()
+    {
+        // Enable billing and set a shop
+        config(['shopify-app.billing_enabled' => true]);
+        session(['shopify_domain' => 'freemium-shop.myshopify.com']);
+
+        $called = false;
+        $result = (new Billable())->handle(request(), function ($request) use (&$called) {
+            // Should be called
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
     public function testDisabledBillingShouldPassOn()
     {
         // Ensure billing is disabled and set a shop

--- a/tests/Models/ChargeModelTest.php
+++ b/tests/Models/ChargeModelTest.php
@@ -3,6 +3,7 @@
 namespace OhMyBrew\ShopifyApp\Test\Models;
 
 use OhMyBrew\ShopifyApp\Models\Charge;
+use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Models\Shop;
 use OhMyBrew\ShopifyApp\Test\Stubs\ApiStub;
 use OhMyBrew\ShopifyApp\Test\TestCase;
@@ -22,6 +23,14 @@ class ChargeModelTest extends TestCase
         $this->assertEquals(
             Charge::CHARGE_RECURRING,
             Charge::find(1)->type
+        );
+    }
+
+    public function testBelongsToPlan()
+    {
+        $this->assertInstanceOf(
+            Plan::class,
+            Charge::find(1)->plan
         );
     }
 

--- a/tests/Models/ChargeModelTest.php
+++ b/tests/Models/ChargeModelTest.php
@@ -12,31 +12,22 @@ class ChargeModelTest extends TestCase
 {
     public function testBelongsToShop()
     {
-        $this->assertInstanceOf(
-            Shop::class,
-            Charge::find(1)->shop
-        );
+        $this->assertInstanceOf(Shop::class, Charge::find(1)->shop);
     }
 
     public function testChargeImplementsType()
     {
-        $this->assertEquals(
-            Charge::CHARGE_RECURRING,
-            Charge::find(1)->type
-        );
+        $this->assertEquals(Charge::CHARGE_RECURRING, Charge::find(1)->type);
     }
 
     public function testBelongsToPlan()
     {
-        $this->assertInstanceOf(
-            Plan::class,
-            Charge::find(1)->plan
-        );
+        $this->assertInstanceOf(Plan::class, Charge::find(1)->plan);
     }
 
     public function testIsTest()
     {
-        $this->assertEquals(true, Charge::find(1)->isTest());
+        $this->assertTrue(Charge::find(1)->isTest());
     }
 
     public function testIsType()

--- a/tests/Models/PlanModelTest.php
+++ b/tests/Models/PlanModelTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OhMyBrew\ShopifyApp\Test\Models;
+
+use OhMyBrew\ShopifyApp\Models\Shop;
+use OhMyBrew\ShopifyApp\Models\Plan;
+use OhMyBrew\ShopifyApp\Test\TestCase;
+use \Illuminate\Database\Eloquent\Collection;
+
+class PlanModelTest extends TestCase
+{
+    public function testReturnsChargesForPlan()
+    {
+        $charges = Plan::find(1)->charges;
+
+        $this->assertInstanceOf(Collection::class, $charges);
+        $this->assertTrue(sizeOf($charges) > 0);
+    }
+
+    public function testReturnsTypeAsString()
+    {
+        $plan = Plan::find(1);
+
+        $this->assertEquals('recurring_application_charge', $plan->typeAsString());
+        $this->assertEquals('recurring_application_charges', $plan->typeAsString(true));
+    }
+
+    public function testPlanHasTrial()
+    {
+        $this->assertFalse(Plan::find(2)->hasTrial());
+        $this->assertTrue(Plan::find(1)->hasTrial());
+    }
+
+    public function testPlanOnInstallFlag()
+    {
+        $this->assertFalse(Plan::find(2)->isOnInstall());
+        $this->assertTrue(Plan::find(1)->isOnInstall());
+    }
+
+    public function testPlanIsTest()
+    {
+        $this->assertTrue(Plan::find(3)->isTest());
+        $this->assertFalse(Plan::find(1)->isTest());
+    }
+}

--- a/tests/Models/ShopModelTest.php
+++ b/tests/Models/ShopModelTest.php
@@ -3,6 +3,7 @@
 namespace OhMyBrew\ShopifyApp\Test\Models;
 
 use OhMyBrew\ShopifyApp\Models\Shop;
+use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Test\TestCase;
 
 class ShopModelTest extends TestCase
@@ -79,5 +80,27 @@ class ShopModelTest extends TestCase
 
         $this->assertEquals(false, $shop->hasCharges());
         $this->assertEquals(true, $shop_2->hasCharges());
+    }
+
+    public function testShopReturnsPlan()
+    {
+        $this->assertInstanceOf(
+            Plan::class,
+            Shop::find(1)->plan
+        );
+    }
+
+    public function testShopReturnsNoPlan()
+    {
+        $this->assertEquals(
+            null,
+            Shop::find(5)->plan
+        );
+    }
+
+    public function testShopIsFreemiumAndNotFreemium()
+    {
+        $this->assertEquals(true, Shop::find(5)->isFreemium());
+        $this->assertEquals(false, Shop::find(1)->isFreemium());
     }
 }

--- a/tests/Models/ShopModelTest.php
+++ b/tests/Models/ShopModelTest.php
@@ -50,8 +50,8 @@ class ShopModelTest extends TestCase
         $shop = Shop::where('shopify_domain', 'grandfathered.myshopify.com')->first();
         $shop_2 = Shop::where('shopify_domain', 'example.myshopify.com')->first();
 
-        $this->assertEquals(true, $shop->isGrandfathered());
-        $this->assertEquals(false, $shop_2->isGrandfathered());
+        $this->assertTrue($shop->isGrandfathered());
+        $this->assertFalse($shop_2->isGrandfathered());
     }
 
     public function testShopCanSoftDeleteAndBeRestored()
@@ -78,29 +78,23 @@ class ShopModelTest extends TestCase
         $shop = Shop::where('shopify_domain', 'grandfathered.myshopify.com')->first();
         $shop_2 = Shop::where('shopify_domain', 'example.myshopify.com')->first();
 
-        $this->assertEquals(false, $shop->hasCharges());
-        $this->assertEquals(true, $shop_2->hasCharges());
+        $this->assertFalse($shop->hasCharges());
+        $this->assertTrue($shop_2->hasCharges());
     }
 
     public function testShopReturnsPlan()
     {
-        $this->assertInstanceOf(
-            Plan::class,
-            Shop::find(1)->plan
-        );
+        $this->assertInstanceOf(Plan::class, Shop::find(1)->plan);
     }
 
     public function testShopReturnsNoPlan()
     {
-        $this->assertEquals(
-            null,
-            Shop::find(5)->plan
-        );
+        $this->assertEquals(null, Shop::find(5)->plan);
     }
 
     public function testShopIsFreemiumAndNotFreemium()
     {
-        $this->assertEquals(true, Shop::find(5)->isFreemium());
-        $this->assertEquals(false, Shop::find(1)->isFreemium());
+        $this->assertTrue(Shop::find(5)->isFreemium());
+        $this->assertFalse(Shop::find(1)->isFreemium());
     }
 }

--- a/tests/Observers/ShopObserverTest.php
+++ b/tests/Observers/ShopObserverTest.php
@@ -19,4 +19,15 @@ class ShopObserverTest extends TestCase
 
         $this->assertEquals('shopify-test-namespace', $shop->namespace);
     }
+
+    public function testObserverSetsFreemiumFlag()
+    {
+        config(['shopify-app.billing_freemium_enabled' => true]);
+
+        $shop = new Shop();
+        $shop->shopify_domain = 'observer-freemium.myshopify.com';
+        $shop->save();
+
+        $this->assertTrue($shop->isFreemium());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace OhMyBrew\ShopifyApp\Test;
 
 use Carbon\Carbon;
 use OhMyBrew\ShopifyApp\Models\Charge;
+use OhMyBrew\ShopifyApp\Models\Plan;
 use OhMyBrew\ShopifyApp\Models\Shop;
 use OhMyBrew\ShopifyApp\ShopifyAppProvider;
 use Orchestra\Database\ConsoleServiceProvider;
@@ -62,6 +63,7 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function seedDatabase()
     {
+        $this->createPlans();
         $this->createShops();
         $this->createCharges();
     }
@@ -73,6 +75,7 @@ abstract class TestCase extends OrchestraTestCase
             [
                 'shopify_domain' => 'example.myshopify.com',
                 'shopify_token'  => '1234',
+                'plan_id' => 1,
             ],
 
             // Non-paid shop, grandfathered
@@ -91,6 +94,12 @@ abstract class TestCase extends OrchestraTestCase
             // New shop... no token, not grandfathered
             [
                 'shopify_domain' => 'no-token-shop.myshopify.com',
+            ],
+
+            // Shop on freemium
+            [
+                'shopify_domain' => 'freemium-shop.myshopify.com',
+                'freemium'       => true,
             ],
         ];
 
@@ -124,6 +133,7 @@ abstract class TestCase extends OrchestraTestCase
                 'trial_days'    => 7,
                 'trial_ends_on' => Carbon::createFromDate(2018, 6, 3, 'UTC')->addWeeks(1)->format('Y-m-d'),
                 'shop_id'       => Shop::where('shopify_domain', 'example.myshopify.com')->first()->id,
+                'plan_id'       => 1,
             ],
 
             // Test = false, status = active, trial = 7, active trial = yes
@@ -137,6 +147,7 @@ abstract class TestCase extends OrchestraTestCase
                 'trial_days'    => 7,
                 'trial_ends_on' => Carbon::today()->addDays(2)->format('Y-m-d'),
                 'shop_id'       => Shop::where('shopify_domain', 'example.myshopify.com')->first()->id,
+                'plan_id'       => 1,
             ],
 
             // Test = false, status = active, trial = 7, active trial = no
@@ -150,6 +161,7 @@ abstract class TestCase extends OrchestraTestCase
                 'trial_days'    => 7,
                 'trial_ends_on' => Carbon::today()->subWeeks(4)->format('Y-m-d'),
                 'shop_id'       => Shop::where('shopify_domain', 'example.myshopify.com')->first()->id,
+                'plan_id'       => 1,
             ],
 
             // Test = false, status = active, trial = 0
@@ -162,6 +174,7 @@ abstract class TestCase extends OrchestraTestCase
                 'price'      => 25.00,
                 'trial_days' => 0,
                 'shop_id'    => Shop::where('shopify_domain', 'example.myshopify.com')->first()->id,
+                'plan_id'    => 2,
             ],
 
             // Test = false, status = declined, trial = 7, active trial = true
@@ -173,6 +186,7 @@ abstract class TestCase extends OrchestraTestCase
                 'type'      => 1,
                 'price'     => 25.00,
                 'shop_id'   => Shop::where('shopify_domain', 'no-token-shop.myshopify.com')->first()->id,
+                'plan_id'   => 1,
             ],
 
             // Test = false, status = cancelled
@@ -185,6 +199,7 @@ abstract class TestCase extends OrchestraTestCase
                 'price'        => 25.00,
                 'shop_id'      => Shop::where('shopify_domain', 'example.myshopify.com')->first()->id,
                 'cancelled_on' => Carbon::today()->format('Y-m-d'),
+                'plan_id'      => 1,
             ],
 
             // Test = false, status = cancelled, trial = 7
@@ -199,6 +214,7 @@ abstract class TestCase extends OrchestraTestCase
                 'trial_ends_on' => Carbon::today()->addWeeks(1)->format('Y-m-d'),
                 'cancelled_on'  => Carbon::today()->addDays(2)->format('Y-m-d'),
                 'shop_id'       => Shop::withTrashed()->where('shopify_domain', 'trashed-shop.myshopify.com')->first()->id,
+                'plan_id'       => 1,
             ],
         ];
 
@@ -209,6 +225,62 @@ abstract class TestCase extends OrchestraTestCase
                 $charge->{$key} = $value;
             }
             $charge->save();
+        }
+    }
+
+    public function createPlans()
+    {
+        $plans = [
+            // Basic Plan with Trial
+            [
+                'type' => 1,
+                'name' => 'Basic Plan with Trial',
+                'price' => 5.00,
+                'trial_days' => 7,
+                'test' => false,
+                'on_install' => true,
+            ],
+
+            // Basic Plan with No Trial
+            [
+                'type' => 1,
+                'name' => 'Basic Plan with No Trial',
+                'price' => 5.00,
+                'trial_days' => 0,
+                'test' => false,
+                'on_install' => false,
+            ],
+
+            // Test Plan
+            [
+                'type' => 2,
+                'name' => 'Test Plan',
+                'price' => 5.00,
+                'trial_days' => 7,
+                'test' => true,
+                'on_install' => false,
+            ],
+
+            // Test Plan
+            [
+                'type' => 1,
+                'name' => 'Capped Plan',
+                'price' => 5.00,
+                'trial_days' => 7,
+                'test' => false,
+                'on_install' => false,
+                'capped_amount' => 100.00,
+                'terms'         => '$1 for 500 emails',
+            ],
+        ];
+
+        // Build the plans
+        foreach ($plans as $planData) {
+            $plan = new Plan();
+            foreach ($planData as $key => $value) {
+                $plan->{$key} = $value;
+            }
+            $plan->save();
         }
     }
 }

--- a/tests/fixtures/14fac79628dbb02150f6bbb072a31620fcc5b445.json
+++ b/tests/fixtures/14fac79628dbb02150f6bbb072a31620fcc5b445.json
@@ -1,0 +1,12 @@
+{
+    "usage_charge": {
+        "id": 1034618208,
+        "description": "One email",
+        "price": "1.00",
+        "created_at": "2018-07-05T13:05:43-04:00",
+        "billing_on": "2018-08-04",
+        "balance_used": 11.0,
+        "balance_remaining": 89.0,
+        "risk_level": 0.08
+    }
+}

--- a/tests/fixtures/9aeb4b1bdd9bc97203c63c008e766f55e9af3a39.json
+++ b/tests/fixtures/9aeb4b1bdd9bc97203c63c008e766f55e9af3a39.json
@@ -1,0 +1,16 @@
+{
+    "application_charge": {
+        "id": 1017262355,
+        "name": "Basic Plan",
+        "api_client_id": 755357713,
+        "price": "5.00",
+        "status": "pending",
+        "return_url": "http://super-duper.shopifyapps.com/",
+        "test": null,
+        "created_at": "2018-07-05T13:11:28-04:00",
+        "updated_at": "2018-07-05T13:11:28-04:00",
+        "charge_type": null,
+        "decorated_return_url": "http://example.shopifyapps.com/?charge_id=1017262355",
+        "confirmation_url": "https://example.myshopify.com/admin/charges/1017262355/confirm_application_charge?signature=BAhpBBMxojw%3D--1139a82a3433b1a6771786e03f02300440e11883"
+    }
+}

--- a/tests/fixtures/c9703dd31785be2b8f0a1a4c5916090542b6e11b.json
+++ b/tests/fixtures/c9703dd31785be2b8f0a1a4c5916090542b6e11b.json
@@ -1,0 +1,12 @@
+{
+    "usage_charge": {
+        "id": 1034618208,
+        "description": "One email",
+        "price": "1.00",
+        "created_at": "2018-07-05T13:05:43-04:00",
+        "billing_on": "2018-08-04",
+        "balance_used": 11.0,
+        "balance_remaining": 89.0,
+        "risk_level": 0.08
+    }
+}


### PR DESCRIPTION
Solves #76, #96, #94 

+ Ability for multi-plan billing and usage charhes built-in
+ Plans are now stored in database (new `plans` table)
+ New `freemium` flag on `shops` table allowing a shop to use the app for "free"
+ New `plan_id` added to `shops` and `charges` tables so a charge and shop can be tied to a plan
+ Config entries modified for `config/shopify-app.php` to support new billing features
+ Charge creation on `BillingController` moved to `firstOrNew` instead of a new instance directly, solving #94
+ Default view added for declined charges or issues with charges, solving #96
+ Addition of `usageCharge` route on `BillingController` to automatically handle creation of usgae charges on a recurring charge, given values passed by get/post
+ `BillingPlan` modified to work with multiple plans
+ Added ability to define a default plan on install