### PR TITLE
Adjustment to job classes for loose checking in constructor

### DIFF
--- a/src/ShopifyApp/Jobs/ScripttagInstaller.php
+++ b/src/ShopifyApp/Jobs/ScripttagInstaller.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use OhMyBrew\ShopifyApp\Models\Shop;
 
 class ScripttagInstaller implements ShouldQueue
 {
@@ -35,7 +34,7 @@ class ScripttagInstaller implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Shop $shop, array $scripttags)
+    public function __construct($shop, array $scripttags)
     {
         $this->shop = $shop;
         $this->scripttags = $scripttags;

--- a/src/ShopifyApp/Jobs/WebhookInstaller.php
+++ b/src/ShopifyApp/Jobs/WebhookInstaller.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use OhMyBrew\ShopifyApp\Models\Shop;
 
 class WebhookInstaller implements ShouldQueue
 {
@@ -35,7 +34,7 @@ class WebhookInstaller implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Shop $shop, array $webhooks)
+    public function __construct($shop, array $webhooks)
     {
         $this->shop = $shop;
         $this->webhooks = $webhooks;


### PR DESCRIPTION
While using ShopModelTrait, base Shop model or its child class is not passed in constructor of two jobs, `WebhookInstaller` and `ScriptTagInstaller`, so we can remove the type hinting from constructor to solve this issue.