### PR TITLE
Fix/Check if is already a JsonResponse

### DIFF
--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -49,7 +50,7 @@ class AuthShop
         $response = $next($request);
         if (($request->ajax() || $request->wantsJson() || $request->isJson()) === false) {
             // Request is not AJAX, continue as normal
-            if (!$response instanceof Response && !$response instanceof RedirectResponse) {
+            if (!$response instanceof Response && !$response instanceof RedirectResponse && !$response instanceof JsonResponse) {
                 // We need a response object to modify headers
                 $response = new Response($response);
             }

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -3,10 +3,10 @@
 namespace OhMyBrew\ShopifyApp\Middleware;
 
 use Closure;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;


### PR DESCRIPTION
An additional fix in regards to https://github.com/ohmybrew/laravel-shopify/issues/164#issuecomment-457462347

> `return response()->json(Model::all());`
> 
> Yields a response that is text/html; charset=UTF-8 but looks like
> 
> ```
> HTTP/1.1 200 OK
> Cache-Control: no-cache, private
> Content-Type:  application/json
> Date:          Fri, 25 Jan 2019 05:39:47 GMT
> 
> []
> ```

