### PR TITLE
Fix incorrect DocBlock

### DIFF
--- a/src/ShopifyApp/Console/stubs/webhook-job.stub
+++ b/src/ShopifyApp/Console/stubs/webhook-job.stub
@@ -28,7 +28,7 @@ class DummyClass implements ShouldQueue
      * Create a new job instance.
      *
      * @param string $shopDomain The shop's myshopify domain
-     * @param object $webhook    The webhook data (JSON decoded)
+     * @param object $data    The webhook data (JSON decoded)
      *
      * @return void
      */


### PR DESCRIPTION
Fixing incorrect variable name in DocBlock . Used the same naming as in `src/ShopifyApp/Jobs/AppUninstalledJob.php`