### PR TITLE
Bugfix - when shopDomainSession is not equal $shopDomainParam from request

### DIFF
--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -60,7 +60,7 @@ class AuthShop
         if ($shop === null
             || $shop->trashed()
             || ($shopDomain && $shopDomain !== $shop->shopify_domain) === true
-//            || ($shopDomain && $shopDomainSession && $shopDomain !== $shopDomainSession ) === true
+            || ($shopDomain && $shopDomainSession && $shopDomain !== $shopDomainSession ) === true
         ) {
             // We need to do a full flow
             $flowType = AuthShopHandler::FLOW_FULL;

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -56,7 +56,11 @@ class AuthShop
         $session->setShop($shop);
 
         $flowType = null;
-        if ($shop === null || $shop->trashed() || ($shopDomain && $shopDomain !== $shop->shopify_domain) === true) {
+        if ($shop === null
+            || $shop->trashed()
+            || ($shopDomain && $shopDomain !== $shop->shopify_domain) === true
+            || ($shopDomain && $shopDomainSession && $shopDomain !== $shopDomainSession ) === true
+        ) {
             // We need to do a full flow
             $flowType = AuthShopHandler::FLOW_FULL;
         } elseif (!$session->isValid()) {

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -86,7 +86,8 @@ class ShopSession
     public function getType()
     {
         $config = Config::get('shopify-app.api_grant_mode');
-        if ($config === self::GRANT_PERUSER) {
+        if ($config === self::GRANT_PERUSER)
+        {
             return self::GRANT_PERUSER;
         }
 
@@ -143,7 +144,8 @@ class ShopSession
         $token = $access->access_token;
 
         // Per-User
-        if (property_exists($access, 'associated_user')) {
+        if (property_exists($access, 'associated_user'))
+        {
             // We have a user, so access will live only in session
             $this->user = $access->associated_user;
 
@@ -174,7 +176,8 @@ class ShopSession
             self::GRANT_OFFLINE => $this->shop->{self::TOKEN},
         ];
 
-        if ($strict) {
+        if ($strict)
+        {
             // We need the token matching the type
             return $tokens[$this->getType()];
         }
@@ -211,7 +214,8 @@ class ShopSession
     public function forget()
     {
         $keys = [self::DOMAIN, self::USER, self::TOKEN];
-        foreach ($keys as $key) {
+        foreach ($keys as $key)
+        {
             Session::forget($key);
         }
     }
@@ -224,7 +228,11 @@ class ShopSession
     public function isValid()
     {
         // No token set or domain in session?
-        return !empty($this->getToken(true)) && $this->getDomain() !== null;
+        $result = ! empty($this->getToken(true))
+            && $this->getDomain() !== null
+            && $this->getDomain() == $this->shop->shopify_domain;
+        
+        return $result;
     }
 
     /**

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -231,7 +231,7 @@ class ShopSession
         $result = ! empty($this->getToken(true))
             && $this->getDomain() !== null
             && $this->getDomain() == $this->shop->shopify_domain;
-        
+
         return $result;
     }
 


### PR DESCRIPTION
Hi @ohmybrew , when i was debugging to find the solutions for https://github.com/ohmybrew/laravel-shopify/issues/289 i found another issue. 

<img width="1440" alt="Screenshot 2019-07-28 at 21 32 22" src="https://user-images.githubusercontent.com/2176503/62012154-c7f38180-b182-11e9-884d-cfdce383ec11.png">

In the screenshot you can see that the shopDomainSession is not equal the shopDomainParam. For the first time you call the App via ShopifyAdmin->Apps->YourApp thats no problem but when you are inside the App and click somewhere you will see the content of the Shop that comes from shopDomainSession.

You can easily test it with 2 stores using the same App.

If you have questions, feel free to ask them :)