### PR TITLE
try to get shop-domain from header

### DIFF
--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -48,7 +48,7 @@ class AuthShop
         $session = new ShopSession();
 
         // Grab the shop's myshopify domain from query or session
-        $shopDomainParam = $request->get('shop');
+        $shopDomainParam = $request->get('shop') ?? $request->header('shop');
         $shopDomainSession = $session->getDomain();
         $shopDomain = ShopifyApp::sanitizeShopDomain($shopDomainParam ?? $shopDomainSession);
 


### PR DESCRIPTION
because we have this issue https://github.com/ohmybrew/laravel-shopify/issues/295 i try also to get the shopify_domain from the header. in our app we set the header by 

`window.axios.defaults.headers.common['shop'] = document.head.querySelector('meta[name="shop"]').content` 