### PR TITLE
Fix for session clashes

### DIFF
--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -110,7 +110,7 @@ class AuthShop
      *
      * @return bool|string
      */
-    protected function getShopDomain(Request $request, ShopSession $session)
+    private function getShopDomain(Request $request, ShopSession $session)
     {
         // Query variable is highest priority
         $shopDomainParam = $request->get('shop');
@@ -146,7 +146,7 @@ class AuthShop
      *
      * @return bool|string
      */
-    protected function getRefererDomain(Request $request)
+    private function getRefererDomain(Request $request)
     {
         // Extract the referer
         $referer = $request->header('referer');

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -39,6 +39,10 @@ class AuthShop
     /**
      * Get the referer shopify domain from the request and validate.
      *
+     * It is dangerous to blindly trust user input so we need to
+     * check and confirm the validity upfront before we return the
+     * value to anything.
+     *
      * @param \Illuminate\Http\Request $request
      *
      * @return bool|string
@@ -74,6 +78,23 @@ class AuthShop
 
     /**
      * Grab the shop's myshopify domain from query, referer or session.
+     *
+     * Getting the domain for the shop from session is unreliable
+     * because if 2 shops have the same app open in the same browser
+     * (e.g. someone is managing the same app on 2 stores at the same
+     * time) then the sessions can bleed into each other due to the
+     * cookies being run on the same domain (the domain of the app,
+     * not the individual shops admin dashboard).
+     *
+     * To get around this select a domain based on other information
+     * available, and make sure to verify the input before use. This is
+     * still not 100% reliable.
+     *
+     * Order of precedence is:
+     *
+     *  - GET variable
+     *  - Referer
+     *  - Session
      *
      * @param \Illuminate\Http\Request                  $request
      * @param \OhMyBrew\ShopifyApp\Services\ShopSession $session

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -37,7 +37,7 @@ class AuthShop
     }
 
     /**
-     * Get the referer shopify domain from the request and validate
+     * Get the referer shopify domain from the request and validate.
      *
      * @param \Illuminate\Http\Request $request
      *
@@ -73,9 +73,9 @@ class AuthShop
     }
 
     /**
-     * Grab the shop's myshopify domain from query, referer or session
+     * Grab the shop's myshopify domain from query, referer or session.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request                  $request
      * @param \OhMyBrew\ShopifyApp\Services\ShopSession $session
      *
      * @return bool|string

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -102,7 +102,7 @@ class AuthShop
         }
 
         // No domain :(
-        return false;
+        throw new Exception('Unable to get shop domain.');
     }
 
     /**
@@ -120,9 +120,6 @@ class AuthShop
         $session = new ShopSession();
 
         $shopDomain = $this->getShopDomain($request, $session);
-        if (!$shopDomain) {
-            throw new Exception('Unable to get shop domain.');
-        }
 
         // Get the shop based on domain and update the session service
         $shopModel = Config::get('shopify-app.shop_model');

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -41,8 +41,6 @@ class AuthShop
      *
      * @param \Illuminate\Http\Request $request
      *
-     * @throws Exception
-     *
      * @return bool|\Illuminate\Http\RedirectResponse
      */
     protected function validateShop(Request $request)
@@ -107,6 +105,8 @@ class AuthShop
      *
      * @param \Illuminate\Http\Request                  $request
      * @param \OhMyBrew\ShopifyApp\Services\ShopSession $session
+     *
+     * @throws Exception
      *
      * @return bool|string
      */

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -52,6 +52,12 @@ class AuthShop
         $shopDomainSession = $session->getDomain();
         $shopDomain = ShopifyApp::sanitizeShopDomain($shopDomainParam ?? $shopDomainSession);
 
+        // See issue https://github.com/ohmybrew/laravel-shopify/issues/295
+        parse_str(parse_url($request->header('referer'), PHP_URL_QUERY), $refererQueryParams);
+        if (isset($refererQueryParams['shop']) && $shopDomain !== $refererQueryParams['shop'] && ShopifyApp::api()->verifyRequest($refererQueryParams)) {
+            $shopDomain = $refererQueryParams['shop'];
+        }
+
         // Get the shop based on domain and update the session service
         $shopModel = Config::get('shopify-app.shop_model');
         $shop = $shopModel::withTrashed()

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -144,7 +144,7 @@ class AuthShopMiddlewareTest extends TestCase
             // Files
             null,
             // Server vars
-            // This should be ignored as there is a get variable
+            // This valid referer should be ignored as there is a get variable
             array_merge(Request::server(), [
                 'HTTP_REFERER' => 'https://xxx.com?shop=example.myshopify.com&hmac=a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163&timestamp=1337178173&code=1234678',
             ])
@@ -159,7 +159,7 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=queryshop.myshopify.com') !== false);
     }
 
-    public function testShopHasWithRefererShouldLoadRefererDomain()
+    public function testShopWithValidRefererShouldLoadRefererDomain()
     {
         // Set a shop
         $shop = factory(Shop::class)->create();
@@ -195,7 +195,7 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=example.myshopify.com') !== false);
     }
 
-    public function testShopHasWithMissingRefererDetailsShouldLoadSessionDomain()
+    public function testShopWithMissingRefererDetailsShouldLoadSessionDomain()
     {
         // Set a shop
         $shop = factory(Shop::class)->create();
@@ -232,7 +232,7 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=sessionz.myshopify.com') !== false);
     }
 
-    public function testShopHasWithBadRefererHmacShouldLoadSessionDomain()
+    public function testShopWithBadRefererHmacShouldLoadSessionDomain()
     {
         // Set a shop
         $shop = factory(Shop::class)->create();

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -269,8 +269,6 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=adsadda.myshopify.com') !== false);
     }
 
-
-
     private function runAuthShop(Closure $cb = null, $requestInstance = null)
     {
         $called = false;


### PR DESCRIPTION
Sessions were clashing when a user was managing the same app for multiple stores in the same browser.

Both stores have the same session due to them both using the app domain in the same browser.

This was leading to store A overwriting store B or vice-versa.

A solution for normal req/resp apps (i.e. not SPAs) is to check the referer header to see exactly which store we're dealing with.

Because the referer header is spoofable we make sure that there is a valid HMAC signature present in the referer.

If there is a shop domain with a valid HMAC signature in the referer header then we overwrite the shopDomain variable to make sure the correct store is loaded.

Resolves https://github.com/ohmybrew/laravel-shopify/issues/295