### PR TITLE
Security Fix for A4 IDOR Vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ This project is released under the MIT [license](https://github.com/ohmybrew/lar
 ## Misc
 
 I develop this package in my spare time, with a busy family/work life like many of you! So, I would like to thank everyone who's helped me out from submitting PRs, to assisting on issues, and plain using the package (I hope its useful). Cheers.
+

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -154,23 +154,22 @@ class AuthShop
             return false;
         }
 
-        $signatureHeaderParam = $request->input('hmac');
-        $timeHeaderParam = $request->input('timestamp');
-        $codeHeaderParam = $request->input('code');
+        $signature = $request->input('hmac');
+        $timestamp = $request->input('timestamp');
+        $code = $request->input('code');
 
         // Make sure there is no param spoofing attempt
         if (ShopifyApp::api()->verifyRequest([
             'shop' => $shop,
-            'hmac' => $signatureHeaderParam,
-            'timestamp' => $timeHeaderParam,
-            'code' => $codeHeaderParam,
+            'hmac' => $signature,
+            'timestamp' => $timestamp,
+            'code' => $code,
         ])) {
             return $shop;
         }
 
         throw new Exception('Unable to verify signature.');
     }
-
 
     /**
      * Get the referer shopify domain from the request and validate.
@@ -207,7 +206,7 @@ class AuthShop
             return $refererQueryParams['shop'];
         }
 
-        return false;
+        throw new Exception('Unable to verify signature.');
     }
 
     /**
@@ -231,16 +230,16 @@ class AuthShop
             return false;
         }
 
-        $signatureHeaderParam = $request->header('X-Shop-Signature');
-        $timeHeaderParam = $request->header('X-Shop-Time');
-        $codeHeaderParam = $request->header('X-Shop-Code');
+        $signature = $request->header('X-Shop-Signature');
+        $timestamp = $request->header('X-Shop-Time');
+        $code = $request->header('X-Shop-Code');
 
         // Make sure there is no param spoofing attempt
         if (ShopifyApp::api()->verifyRequest([
             'shop' => $shop,
-            'hmac' => $signatureHeaderParam,
-            'timestamp' => $timeHeaderParam,
-            'code' => $codeHeaderParam,
+            'hmac' => $signature,
+            'timestamp' => $timestamp,
+            'code' => $code,
         ])) {
             return $shop;
         }

--- a/src/ShopifyApp/Middleware/AuthShop.php
+++ b/src/ShopifyApp/Middleware/AuthShop.php
@@ -74,7 +74,8 @@ class AuthShop
     }
 
     /**
-     * Grab the shop's myshopify domain from query, referer or session.
+     * Grab the shop's myshopify domain from query, referer, headers
+     * or session.
      *
      * Getting the domain for the shop from session is unreliable
      * because if 2 shops have the same app open in the same browser
@@ -89,8 +90,9 @@ class AuthShop
      *
      * Order of precedence is:
      *
-     *  - GET variable
+     *  - GET/POST Variable
      *  - Referer
+     *  - Headers
      *  - Session
      *
      * @param \Illuminate\Http\Request                  $request
@@ -115,15 +117,16 @@ class AuthShop
             return ShopifyApp::sanitizeShopDomain($shopRefererParam);
         }
 
-        // Grab the shop's myshopify domain from query or session
-        // For SPA's we need X-Shop-Domain
+        // Grab the shop's myshopify domain from headers
+        // Referer is more reliable
+        // For SPA's we need X-Shop-Domain and verification headers
         // See issue https://github.com/ohmybrew/laravel-shopify/issues/295
         $shopHeaderParam = $this->getHeaderDomain($request);
         if ($shopHeaderParam) {
             return ShopifyApp::sanitizeShopDomain($shopHeaderParam);
         }
 
-        // If neither are available then pull from the session
+        // If none of the above are available then pull from the session
         $shopDomainSession = $session->getDomain();
         if ($shopDomainSession) {
             return ShopifyApp::sanitizeShopDomain($shopDomainSession);

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -285,6 +285,10 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=sessionz.myshopify.com') !== false);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unable to verify signature.
+     */
     public function testShopWithBadRefererHmacShouldLoadSessionDomain()
     {
         // Set a shop
@@ -314,12 +318,8 @@ class AuthShopMiddlewareTest extends TestCase
 
         Request::swap($newRequest);
 
+        // Should throw exception
         $result = $this->runAuthShop();
-
-        // Assert it was not called and a redirect happened
-        $this->assertFalse($result[1]);
-        // Make sure it's the one in the session
-        $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=adsadda.myshopify.com') !== false);
     }
 
     public function testShopWithEmptyRefererShouldLoadSessionDomain()

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -441,7 +441,6 @@ class AuthShopMiddlewareTest extends TestCase
         $result = $this->runAuthShop();
     }
 
-
     private function runAuthShop(Closure $cb = null, $requestInstance = null)
     {
         $called = false;

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -66,21 +66,27 @@ class AuthShopMiddlewareTest extends TestCase
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate') !== false);
     }
 
-    public function testShopsWhichDoNotMatchShouldKillSessionAndDirectToReAuthenticate()
+    public function testValidShopsWhichDoNotMatchShouldKillSessionAndDirectToReAuthenticate()
     {
         // Set a shop
         $shop = factory(Shop::class)->create();
         Session::put('shopify_domain', $shop->shopify_domain);
 
         // Go in as a new shop
-        Input::merge(['shop' => 'example-different-shop.myshopify.com']);
+        Input::merge([
+            'shop' => 'example.myshopify.com',
+            'hmac' => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
+            'timestamp' => '1337178173',
+            'code' => '1234678',
+        ]);
 
         // Run the middleware
         $result = $this->runAuthShop();
 
         // Assert it was not called and the new shop was passed
+        $this->assertNull(Session::get('shopify_domain'));
         $this->assertFalse($result[1]);
-        $this->assertEquals('example-different-shop.myshopify.com', Request::get('shop'));
+        $this->assertEquals('example.myshopify.com', Request::get('shop'));
     }
 
     public function testGrantTypePerUserWithInvalidSessionShouldDirectToReAuthenticate()
@@ -115,6 +121,7 @@ class AuthShopMiddlewareTest extends TestCase
         $result = $this->runAuthShop();
 
         // Assert it was not called and a redirect happened
+        $this->assertNull(Session::get('shopify_domain'));
         $this->assertFalse($result[1]);
         $this->assertEquals('http://localhost/orders', Session::get('return_to'));
         $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate') !== false);
@@ -123,7 +130,7 @@ class AuthShopMiddlewareTest extends TestCase
         // Request::swap($currentRequest);
     }
 
-    public function testShopWithGetShouldLoadGetDomain()
+    public function testShopWithValidGetShouldLoadGetDomain()
     {
         // Set a shop
         $shop = factory(Shop::class)->create();
@@ -134,7 +141,12 @@ class AuthShopMiddlewareTest extends TestCase
         $currentRequest = Request::instance();
         $newRequest = $currentRequest->duplicate(
             // Query Params
-            ['shop' => 'queryshop.myshopify.com'],
+            [
+                'shop' => 'example.myshopify.com',
+                'hmac' => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
+                'timestamp' => '1337178173',
+                'code' => '1234678'
+            ],
             // Request Params
             null,
             // Attributes
@@ -146,7 +158,7 @@ class AuthShopMiddlewareTest extends TestCase
             // Server vars
             // This valid referer should be ignored as there is a get variable
             array_merge(Request::server(), [
-                'HTTP_REFERER' => 'https://xxx.com?shop=example.myshopify.com&hmac=a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163&timestamp=1337178173&code=1234678',
+                'HTTP_REFERER' => 'https://xxx.com?shop=xyz.com',
             ])
         );
 
@@ -156,7 +168,48 @@ class AuthShopMiddlewareTest extends TestCase
 
         // Assert it was not called and a redirect happened
         $this->assertFalse($result[1]);
-        $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=queryshop.myshopify.com') !== false);
+        $this->assertTrue(strpos($result[0], 'Redirecting to http://localhost/authenticate/full?shop=example.myshopify.com') !== false);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unable to verify signature.
+     */
+    public function testShopWithInvalidGetShouldFail()
+    {
+        // Set a shop
+        $shop = factory(Shop::class)->create();
+        // this should get ignored as there is a get variable
+        Session::put('shopify_domain', 'adsadda');
+
+        // Run the middleware
+        $currentRequest = Request::instance();
+        $newRequest = $currentRequest->duplicate(
+            // Query Params
+            [
+                'shop' => 'example.myshopify.com',
+                'hmac' => 'XXXXX',
+                'timestamp' => '1337178173',
+                'code' => '1234678'
+            ],
+            // Request Params
+            null,
+            // Attributes
+            null,
+            // Cookies
+            null,
+            // Files
+            null,
+            // Server vars
+            // This valid referer should be ignored as there is a get variable
+            array_merge(Request::server(), [
+                'HTTP_REFERER' => 'https://xxx.com?shop=xyz.com',
+            ])
+        );
+
+        Request::swap($newRequest);
+
+        $result = $this->runAuthShop();
     }
 
     public function testShopWithValidRefererShouldLoadRefererDomain()

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -74,10 +74,10 @@ class AuthShopMiddlewareTest extends TestCase
 
         // Go in as a new shop
         Input::merge([
-            'shop' => 'example.myshopify.com',
-            'hmac' => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
+            'shop'      => 'example.myshopify.com',
+            'hmac'      => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
             'timestamp' => '1337178173',
-            'code' => '1234678',
+            'code'      => '1234678',
         ]);
 
         // Run the middleware
@@ -142,10 +142,10 @@ class AuthShopMiddlewareTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
-                'shop' => 'example.myshopify.com',
-                'hmac' => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
+                'shop'      => 'example.myshopify.com',
+                'hmac'      => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
                 'timestamp' => '1337178173',
-                'code' => '1234678'
+                'code'      => '1234678',
             ],
             // Request Params
             null,
@@ -187,10 +187,10 @@ class AuthShopMiddlewareTest extends TestCase
         $newRequest = $currentRequest->duplicate(
             // Query Params
             [
-                'shop' => 'example.myshopify.com',
-                'hmac' => 'XXXXX',
+                'shop'      => 'example.myshopify.com',
+                'hmac'      => 'XXXXX',
                 'timestamp' => '1337178173',
-                'code' => '1234678'
+                'code'      => '1234678',
             ],
             // Request Params
             null,
@@ -386,7 +386,7 @@ class AuthShopMiddlewareTest extends TestCase
             ])
         );
 
-        $newRequest->headers->set('X-Shop-Domain','example.myshopify.com');
+        $newRequest->headers->set('X-Shop-Domain', 'example.myshopify.com');
         $newRequest->headers->set('X-Shop-Signature', 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163');
         $newRequest->headers->set('X-Shop-Time', '1337178173');
         $newRequest->headers->set('X-Shop-Code', '1234678');
@@ -432,7 +432,7 @@ class AuthShopMiddlewareTest extends TestCase
             ])
         );
 
-        $newRequest->headers->set('X-Shop-Domain','example.com');
+        $newRequest->headers->set('X-Shop-Domain', 'example.com');
         $newRequest->headers->set('X-Shop-Signature', 'XXXXXXXX');
 
         Request::swap($newRequest);


### PR DESCRIPTION
### Problem

It was possible for an attacker to successfully load a different stores information into memory via insecure direct object references.

You could simply change the domain in the get variables to another valid store and the application would successfully load their shop.

To fix this we add verification at the point of entry, and before we load the target shops sensitive model data into memory.

### Explanation

- [Line 52](https://github.com/ohmybrew/laravel-shopify/blob/master/src/ShopifyApp/Middleware/AuthShop.php#L52) loads the shop specified by the user
- [Line 59](https://github.com/ohmybrew/laravel-shopify/blob/master/src/ShopifyApp/Middleware/AuthShop.php#L59) then loads this value, without any validation, into the session

From that point on the arbitrary target shop is loaded. It's important that user input gets sanitised and checked before doing any processing on it.

### Changes

- Require signature verification before loading any shops
- Refactor loading from query variables
- Refactor loading from headers
- Allow submission of details via POST as well as GET
- Use correct header variable when loading from headers
- Add load shop from query param signature validation
- Add load shop from header param signature validation
- Add load shop from referer signature failed exception
- Updated all tests

### Impact

This requires no changes for shops that:

1. Use GET variables like normal (still passes as long as no fiddling)
2. Rely on the Referer variable, like a normal req/resp site (throws exception if fiddling)
3. Fall back to Session value

This only requires changes for shops that:

1. Want to use the new loading domain from headers functionality - they must include the signature details in their request (unreleased feature)
2. Use a GET variable without a signature (a hack that should not be allowed to happen)

### Usage

#### For SPAs

Track and append 4x values on requests:

- `X-Shop-Domain` - the domain of the target store
- `X-Shop-Signature` - the signature (a.k.a. hmac)
- `X-Shop-Time` - the timestamp used in the creation of the signature
- `X-Shop-Code` - the code used in the creation of the signature

If these values have been tampered with an exception will throw.

#### For GET/POST

Exactly like before, in the same way that Shopify prescribes.

- `shop` - the domain of the target store
- `hmac` - the signature
- `timestamp` - the timestamp
- `code` - the code

If these values have been tampered with an exception will throw.

#### For Referer

- If the referer does not have all 4 values in the GET vars the loading via referer will skip.
- If the referer has all 4 values but the verification fails an exception will throw.

#### For Session

If none of the above is present then the shop domain will be loaded from session.

This is an acceptable risk because to take over a store an attacker would have to steal another stores cookie (unlike before where they could just modify a query param).