### PR TITLE
Laravel 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - LARAVEL_VERSION=5.6.*
   - LARAVEL_VERSION=5.7.*
   - LARAVEL_VERSION=5.8.*
-  - LARAVEL_VERSION-6.0.*
+  - LARAVEL_VERSION=6.0.*
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - LARAVEL_VERSION=5.6.*
   - LARAVEL_VERSION=5.7.*
   - LARAVEL_VERSION=5.8.*
+  - LARAVEL_VERSION-6.0.*
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+  - php: 7.1
+    env: LARAVEL_VERSION=6.0.*
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/framework": "~5.6",
+        "laravel/framework": "~5.6 | ^6.0",
         "ohmybrew/basic-shopify-api": "^5.4",
         "doctrine/dbal": "~2.5"
     },
     "require-dev": {
-        "orchestra/database": "~3.6",
-        "orchestra/testbench": "~3.6",
-        "phpunit/phpunit": "~6.0 || ~7.0",
+        "orchestra/database": "~4.0",
+        "orchestra/testbench": "~4.0",
+        "phpunit/phpunit": "~6.0 || ~7.0 || ~8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "mockery/mockery": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "doctrine/dbal": "~2.5"
     },
     "require-dev": {
-        "orchestra/database": "~4.0",
-        "orchestra/testbench": "~4.0",
+        "orchestra/database": "~3.6 | ~4.0",
+        "orchestra/testbench": "~3.6 | ~4.0",
         "phpunit/phpunit": "~6.0 || ~7.0 || ~8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "mockery/mockery": "^1.0"

--- a/tests/Middleware/AuthProxyMiddlewareTest.php
+++ b/tests/Middleware/AuthProxyMiddlewareTest.php
@@ -4,7 +4,6 @@ namespace OhMyBrew\ShopifyApp\Test\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 use OhMyBrew\ShopifyApp\Facades\ShopifyApp;
@@ -35,7 +34,7 @@ class AuthProxyMiddlewareTest extends TestCase
         // Remove shop from params
         $query = $this->queryParams;
         unset($query['shop']);
-        Input::merge($query);
+        Request::merge($query);
 
         // Run the middleware
         $result = $this->runAuthProxy();
@@ -47,7 +46,7 @@ class AuthProxyMiddlewareTest extends TestCase
 
     public function testRuns()
     {
-        Input::merge($this->queryParams);
+        Request::merge($this->queryParams);
 
         // Confirm no shop
         $this->assertNull(Session::get('shopify_domain'));
@@ -71,7 +70,7 @@ class AuthProxyMiddlewareTest extends TestCase
         // Make the signature invalid
         $query = $this->queryParams;
         $query['oops'] = 'i-did-it-again';
-        Input::merge($query);
+        Request::merge($query);
 
         // Run the middleware
         $result = $this->runAuthProxy();

--- a/tests/Middleware/AuthShopMiddlewareTest.php
+++ b/tests/Middleware/AuthShopMiddlewareTest.php
@@ -3,7 +3,6 @@
 namespace OhMyBrew\ShopifyApp\Test\Middleware;
 
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 use OhMyBrew\ShopifyApp\Middleware\AuthShop;
@@ -73,7 +72,7 @@ class AuthShopMiddlewareTest extends TestCase
         Session::put('shopify_domain', $shop->shopify_domain);
 
         // Go in as a new shop
-        Input::merge([
+        Request::merge([
             'shop'      => 'example.myshopify.com',
             'hmac'      => 'a7448f7c42c9bc025b077ac8b73e7600b6f8012719d21cbeb88db66e5dbbd163',
             'timestamp' => '1337178173',


### PR DESCRIPTION
Adding support for Laravel 6.

Note that the `Input` facade has been [deprecated](https://laravel.com/docs/6.0/upgrade#the-input-facade) in favour of `Request`. 2 tests have been updated accordingly. 

Unit tests contain 12 warnings as there are some annotations that are going to be depreciated soon.

This is my first PR here! Any feedback is appreciated!