### PR TITLE
Add App Bridge Version to configuration

### DIFF
--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -71,6 +71,10 @@ return [
 
     'appbridge_enabled' => (bool) env('SHOPIFY_APPBRIDGE_ENABLED', true),
 
+    // Use semver range to link to a major or minor version number.
+    // Leaving empty will use the latest verison - not recommended in production.
+    'appbridge_version' => (bool) env('SHOPIFY_APPBRIDGE_VERSION', '1'),
+
     /*
     |--------------------------------------------------------------------------
     | Shopify App Name

--- a/src/ShopifyApp/resources/views/layouts/default.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/default.blade.php
@@ -19,7 +19,7 @@
         </div>
 
         @if(config('shopify-app.appbridge_enabled'))
-            <script src="https://unpkg.com/@shopify/app-bridge"></script>
+            <script src="https://unpkg.com/@shopify/app-bridge{{ config('shopify-app.appbridge_enabled') ? '@'.config('shopify-app.appbridge_enabled') : '' }}"></script>
             <script>
                 var AppBridge = window['app-bridge'];
                 var createApp = AppBridge.default;

--- a/src/ShopifyApp/resources/views/layouts/default.blade.php
+++ b/src/ShopifyApp/resources/views/layouts/default.blade.php
@@ -19,7 +19,7 @@
         </div>
 
         @if(config('shopify-app.appbridge_enabled'))
-            <script src="https://unpkg.com/@shopify/app-bridge{{ config('shopify-app.appbridge_enabled') ? '@'.config('shopify-app.appbridge_enabled') : '' }}"></script>
+            <script src="https://unpkg.com/@shopify/app-bridge{{ config('shopify-app.appbridge_version') ? '@'.config('shopify-app.appbridge_version') : '' }}"></script>
             <script>
                 var AppBridge = window['app-bridge'];
                 var createApp = AppBridge.default;


### PR DESCRIPTION
This PR add a setting for specifying the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge/getting-started#embed-your-app-in-the-shopify-admin) version that is used in the CDN.

## Why is this needed?
We are right now using the CDN endpoint which uses the latest version of Shopify App Bridge. This may contain breaking changes at some point (like when they go from version `1` to `2`) which would affect the applications using the latest CDN.

See the recommendation from Shopify [here](https://help.shopify.com/en/api/embedded-apps/app-bridge/getting-started#embed-your-app-in-the-shopify-admin):

> It’s not a good idea to automatically consume the latest version of a library in a production app, because a new version might introduce breaking changes.

## Does this break anything?
**NO**. This implements a new configuration which set the default CDN version to `1`. This will automatically use the latest CDN version which is `< 2.0.0`. Current version is `1.6.8`, so implementing this will keep using the latest version.