### PR TITLE
Bug fix: `appbridge_version` incorrectly casting to boolean

### DIFF
--- a/src/ShopifyApp/resources/config/shopify-app.php
+++ b/src/ShopifyApp/resources/config/shopify-app.php
@@ -73,7 +73,7 @@ return [
 
     // Use semver range to link to a major or minor version number.
     // Leaving empty will use the latest verison - not recommended in production.
-    'appbridge_version' => (bool) env('SHOPIFY_APPBRIDGE_VERSION', '1'),
+    'appbridge_version' => env('SHOPIFY_APPBRIDGE_VERSION', '1'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Spotted a typo in the new `appbridge_version` config incorrectly casting to a boolean, resulting in the URL to app bridge always returning a 1 or a 0 rather than the actual config value.