### PR TITLE
Typo: changed `shopify-app.debug` key to `app.debug`

### DIFF
--- a/src/ShopifyApp/Exceptions/BaseException.php
+++ b/src/ShopifyApp/Exceptions/BaseException.php
@@ -22,7 +22,7 @@ abstract class BaseException extends Exception
      */
     public function render(Request $request)
     {
-        if (!Config::get('shopify-app.debug')) {
+        if (!Config::get('app.debug')) {
             // If not in debug mode... show view
             return Redirect::route('login')->with('error', $this->getMessage());
         }


### PR DESCRIPTION
I believe @ohmybrew meant to write `app.debug` since `shopify-app.debug` doesn't actually exist. (Reference: https://github.com/ohmybrew/laravel-shopify/issues/327#issuecomment-536872852) 