### PR TITLE
UsageCharge Service - return Charge Model instead of boolean

### DIFF
--- a/src/ShopifyApp/Services/UsageCharge.php
+++ b/src/ShopifyApp/Services/UsageCharge.php
@@ -106,7 +106,8 @@ class UsageCharge
         $charge->price = $this->response->price;
         $charge->description = $this->response->description;
         $charge->billing_on = $this->response->billing_on;
+        $charge->save();
 
-        return $charge->save();
+        return $charge;
     }
 }


### PR DESCRIPTION
Hi @ohmybrew , we extended the charges table for usageCharges and saw that the save method just return the result of the eloquent save operation. To get the charge model after saving we changed this. Please take a look and maybe discuss :)

Have a nive day! Stefan