### PR TITLE
Fix broken auth

### DIFF
--- a/src/ShopifyApp/Traits/AuthControllerTrait.php
+++ b/src/ShopifyApp/Traits/AuthControllerTrait.php
@@ -45,8 +45,6 @@ trait AuthControllerTrait
 
         // Start the process
         $auth = new AuthShopHandler($shop);
-        $session = new ShopSession($shop);
-        $session->setDomain($shopDomain);
 
         if (!$request->filled('code')) {
             // Handle a request without a code, do a fullpage redirect
@@ -66,6 +64,8 @@ trait AuthControllerTrait
 
         // We have a good code, get the access details
         $access = $auth->getAccess($validated['code']);
+        $session = new ShopSession($shop);
+        $session->setDomain($shopDomain);
         $session->setAccess($access);
 
         // Do post processing and dispatch the jobs


### PR DESCRIPTION
Shop should be added to session only when the code from shopify is valid. 
Right now you can login to any app using offline grant by going to app_url/authenticate?shop=shopdomain, after that you go to the app and you are logged in.