### PR TITLE
Bug fix for incorrect SameSite=none behaviour on some platforms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ env:
   - LARAVEL_VERSION=5.6.*
   - LARAVEL_VERSION=5.7.*
   - LARAVEL_VERSION=5.8.*
-  - LARAVEL_VERSION=6.0.*
+  - LARAVEL_VERSION=^6.0
 
 matrix:
   fast_finish: true
   exclude:
   - php: 7.1
-    env: LARAVEL_VERSION=6.0.*
+    env: LARAVEL_VERSION=^6.0
 
 cache:
   directories:

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -299,19 +299,19 @@ class ShopSession
                 $compatible = true;
             }
 
-            if ($this->agent->is('iOS') && $platform['float'] > 12) {
+            if ($this->agent->is('iOS') && $platform['float'] >= 13) {
                 $compatible = true;
             }
 
             if ($this->agent->is('OS X') &&
                 ($this->agent->is('Safari') && !$this->agent->is('iOS')) &&
-                $platform['float'] > 10.14
+                $platform['float'] >= 10.15
             ) {
                 $compatible = true;
             }
 
             if ($this->agent->is('UCBrowser') &&
-                $browser['float'] > 12.13
+                $browser['float'] >= 12.132
             ) {
                 $compatible = true;
             }

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -295,11 +295,11 @@ class ShopSession
             $browser = $this->getBrowserDetails();
             $platform = $this->getPlatformDetails();
 
-            if ($this->agent->is('Chrome') && $browser['major'] >= 67) {
+            if ($this->agent->is('Chrome') && $browser['float'] >= 67) {
                 $compatible = true;
             }
 
-            if ($this->agent->is('iOS') && $platform['major'] > 12) {
+            if ($this->agent->is('iOS') && $platform['float'] > 12) {
                 $compatible = true;
             }
 
@@ -329,13 +329,10 @@ class ShopSession
      */
     private function getBrowserDetails()
     {
-        $version = $this->agent->version($this->agent->browser());
-        $pieces = explode('.', str_replace('_', '.', $version));
+        $version = $this->agent->version($this->agent->browser(), Agent::VERSION_TYPE_FLOAT);
 
         return [
-            'major' => $pieces[0],
-            'minor' => $pieces[1],
-            'float' => (float) sprintf('%s.%s', $pieces[0], $pieces[1]),
+            'float' => $version,
         ];
     }
 
@@ -346,13 +343,10 @@ class ShopSession
      */
     private function getPlatformDetails()
     {
-        $version = $this->agent->version($this->agent->platform());
-        $pieces = explode('.', str_replace('_', '.', $version));
+        $version = $this->agent->version($this->agent->platform(), Agent::VERSION_TYPE_FLOAT);
 
         return [
-            'major' => $pieces[0],
-            'minor' => $pieces[1],
-            'float' => (float) sprintf('%s.%s', $pieces[0], $pieces[1]),
+            'float' => $version,
         ];
     }
 }

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -295,7 +295,7 @@ class ShopSession
             $browser = $this->getBrowserDetails();
             $platform = $this->getPlatformDetails();
 
-            if ($this->agent->is('Chrome') && $browser['float'] < 67) {
+            if ($this->agent->browser() == 'Chrome' && $browser['float'] < 67) {
                 $compatible = false;
             }
 
@@ -304,13 +304,13 @@ class ShopSession
             }
 
             if ($this->agent->is('OS X') &&
-                ($this->agent->is('Safari') && !$this->agent->is('iOS')) &&
+                ($this->agent->browser() == 'Safari' && !$this->agent->is('iOS')) &&
                 $platform['float'] < 10.15
             ) {
                 $compatible = false;
             }
 
-            if ($this->agent->is('UCBrowser') &&
+            if ($this->agent->browser() == 'UCBrowser' &&
                 $browser['float'] < 12.132
             ) {
                 $compatible = false;

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -291,35 +291,31 @@ class ShopSession
 
         $this->agent = new Agent();
 
-        try {
-            $browser = $this->getBrowserDetails();
-            $platform = $this->getPlatformDetails();
+        $browser = $this->getBrowserDetails();
+        $platform = $this->getPlatformDetails();
 
-            if ($this->agent->browser() == 'Chrome' && $browser['float'] < 67) {
-                $compatible = false;
-            }
-
-            if ($this->agent->is('iOS') && $platform['float'] < 13) {
-                $compatible = false;
-            }
-
-            if ($this->agent->is('OS X') &&
-                ($this->agent->browser() == 'Safari' && !$this->agent->is('iOS')) &&
-                $platform['float'] < 10.15
-            ) {
-                $compatible = false;
-            }
-
-            if ($this->agent->browser() == 'UCBrowser' &&
-                $browser['float'] < 12.132
-            ) {
-                $compatible = false;
-            }
-
-            return $compatible;
-        } catch (\Exception $e) {
-            return true;
+        if ($this->agent->browser() == 'Chrome' && $browser['float'] < 67) {
+            $compatible = false;
         }
+
+        if ($this->agent->is('iOS') && $platform['float'] < 13) {
+            $compatible = false;
+        }
+
+        if ($this->agent->is('OS X') &&
+            ($this->agent->browser() == 'Safari' && !$this->agent->is('iOS')) &&
+            $platform['float'] < 10.15
+        ) {
+            $compatible = false;
+        }
+
+        if ($this->agent->browser() == 'UCBrowser' &&
+            $browser['float'] < 12.132
+        ) {
+            $compatible = false;
+        }
+
+        return $compatible;
     }
 
     /**

--- a/src/ShopifyApp/Services/ShopSession.php
+++ b/src/ShopifyApp/Services/ShopSession.php
@@ -287,7 +287,7 @@ class ShopSession
      */
     private function checkSameSiteNoneCompatible()
     {
-        $compatible = false;
+        $compatible = true;
 
         $this->agent = new Agent();
 
@@ -295,30 +295,30 @@ class ShopSession
             $browser = $this->getBrowserDetails();
             $platform = $this->getPlatformDetails();
 
-            if ($this->agent->is('Chrome') && $browser['float'] >= 67) {
-                $compatible = true;
+            if ($this->agent->is('Chrome') && $browser['float'] < 67) {
+                $compatible = false;
             }
 
-            if ($this->agent->is('iOS') && $platform['float'] >= 13) {
-                $compatible = true;
+            if ($this->agent->is('iOS') && $platform['float'] < 13) {
+                $compatible = false;
             }
 
             if ($this->agent->is('OS X') &&
                 ($this->agent->is('Safari') && !$this->agent->is('iOS')) &&
-                $platform['float'] >= 10.15
+                $platform['float'] < 10.15
             ) {
-                $compatible = true;
+                $compatible = false;
             }
 
             if ($this->agent->is('UCBrowser') &&
-                $browser['float'] >= 12.132
+                $browser['float'] < 12.132
             ) {
-                $compatible = true;
+                $compatible = false;
             }
 
             return $compatible;
         } catch (\Exception $e) {
-            return false;
+            return true;
         }
     }
 
@@ -332,7 +332,7 @@ class ShopSession
         $version = $this->agent->version($this->agent->browser(), Agent::VERSION_TYPE_FLOAT);
 
         return [
-            'float' => $version,
+            'float' => ($version ?: 0),
         ];
     }
 
@@ -346,7 +346,7 @@ class ShopSession
         $version = $this->agent->version($this->agent->platform(), Agent::VERSION_TYPE_FLOAT);
 
         return [
-            'float' => $version,
+            'float' => ($version ?: 0),
         ];
     }
 }

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -126,7 +126,6 @@ class ShopSessionTest extends TestCase
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
             'Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30',
             'UCWEB/2.0 (Java; U; MIDP-2.0; en-US; generic) U2/1.0.0 UCBrowser/9.5.0.449 U2/1.0.0 Mobile',
-            'Mozilla/5.0 (Linux; U; Android 9; zh-CN; Nokia X7 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1020 Mobile Safari/537.36',
             'Mozilla/5.0 (iPod; CPU iPhone OS 12_0 like macOS) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/12.0 Mobile/14A5335d Safari/602.1.50',
         ];
 
@@ -137,6 +136,7 @@ class ShopSessionTest extends TestCase
             'Mozilla/5.0 (Linux; U; Android 9; zh-CN; Nokia X7 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.15.0.1020 Mobile Safari/537.36',
             'Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/66.6 Mobile/14A5297c Safari/602.1',
             'Mozilla/5.0 (Linux; U; Android 7.1.2; en-US; GT-N5110 Build/NJH47F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1221 Mobile Safari/537.36',
+            'Mozilla/5.0 (Linux; U; Android 9; zh-CN; Nokia X7 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1020 Mobile Safari/537.36',
             'UCWEB/2.0 (Java; U; MIDP-2.0; en-US; generic) U2/1.0.0 UCBrowser/12.15.0.449 U2/2.0.0 Mobile',
         ];
 

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -152,6 +152,12 @@ class ShopSessionTest extends TestCase
         $shop = factory(Shop::class)->create();
 
         foreach ($badUserAgents as $agent) {
+            // reset sessions before each test
+            config([
+                'session.secure'    => false,
+                'session.same_site' => null,
+            ]);
+
             $_SERVER['HTTP_USER_AGENT'] = $agent;
             $response = $this->get('/');
 
@@ -160,6 +166,12 @@ class ShopSessionTest extends TestCase
         }
 
         foreach ($incompatibleUserAgents as $agent) {
+            // reset sessions before each test
+            config([
+                'session.secure'    => false,
+                'session.same_site' => null,
+            ]);
+
             $_SERVER['HTTP_USER_AGENT'] = $agent;
             $response = $this->get('/');
 
@@ -168,6 +180,12 @@ class ShopSessionTest extends TestCase
         }
 
         foreach ($compatibleUserAgents as $agent) {
+            // reset sessions before each test
+            config([
+                'session.secure'    => false,
+                'session.same_site' => null,
+            ]);
+
             $_SERVER['HTTP_USER_AGENT'] = $agent;
             $response = $this->get('/');
 

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -155,8 +155,8 @@ class ShopSessionTest extends TestCase
             $_SERVER['HTTP_USER_AGENT'] = $agent;
             $response = $this->get('/');
 
-            $this->assertNull($response->baseResponse->headers->getCookies()[0]->getSameSite());
-            $this->assertFalse($response->baseResponse->headers->getCookies()[0]->isSecure());
+            $this->assertEquals('none', $response->baseResponse->headers->getCookies()[0]->getSameSite());
+            $this->assertTrue($response->baseResponse->headers->getCookies()[0]->isSecure());
         }
 
         foreach ($incompatibleUserAgents as $agent) {

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -140,6 +140,10 @@ class ShopSessionTest extends TestCase
             'Mozilla/5.0 (Linux; U; Android 7.1.2; en-US; GT-N5110 Build/NJH47F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1221 Mobile Safari/537.36',
             'Mozilla/5.0 (Linux; U; Android 9; zh-CN; Nokia X7 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1020 Mobile Safari/537.36',
             'UCWEB/2.0 (Java; U; MIDP-2.0; en-US; generic) U2/1.0.0 UCBrowser/12.15.0.449 U2/2.0.0 Mobile',
+            'Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0',
+            'Mozilla/5.0 zgrab/0.x',
+            'AWS Security Scanner',
+            'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
         ];
 
         $badUserAgents = [

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -122,6 +122,7 @@ class ShopSessionTest extends TestCase
     public function testSameSiteCookie()
     {
         $incompatibleUserAgents = [
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36',
             'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/87.0.279142407 Mobile/15E148 Safari/605.1',
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
             'Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G935F Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30',

--- a/tests/Services/ShopSessionTest.php
+++ b/tests/Services/ShopSessionTest.php
@@ -130,6 +130,7 @@ class ShopSessionTest extends TestCase
         ];
 
         $compatibleUserAgents = [
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.78 Safari/537.36',
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0',
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15',


### PR DESCRIPTION
A bug was discovered from PR #382 in `ShopSession.php`'s new `getBrowserDetails()` and `getPlatformDetails()` method that causes the app to not return SameSite=none on some platforms. This is likely caused by the fact that some platform's version numbers do not have a minor number. 

The proposed fix is to rely on `Jenssegers\Agent`'s built-in functions that can generate a float version number from any user-agent.

Reference: https://github.com/ohmybrew/laravel-shopify/pull/382#issuecomment-581620833_

Other fixes include:
- A mistake in the unit-test, where a compatible UCBrowser user-agent wound up in the incompatible list (confusion probably caused because both "Chrome" and "UCBrowser" is mentioned in the user-agent).
- Flipping the logic from a whitelist to a blacklist, since `SameSite=None` is expected to be a norm on more browsers moving forward ([Refer to this comment](https://github.com/ohmybrew/laravel-shopify/pull/386#issuecomment-581756542))
- Updated Travis Laravel version constraint to properly support Laravel's new Semantic Versioning